### PR TITLE
Implement parser

### DIFF
--- a/ScintillaApp.xcodeproj/xcuserdata/danielle.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ScintillaApp.xcodeproj/xcuserdata/danielle.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,23 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>877AE76F2D3B7143006B9F54</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>877AE7802D3B7144006B9F54</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>877AE78A2D3B7144006B9F54</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -11,15 +11,18 @@ indirect enum Expression<Depth: Equatable>: Equatable {
         public var value: Expression<Depth>
     }
 
+    case binary(Expression, Token, Expression)
     case unary(Token, Expression)
     case literal(Token, ScintillaValue)
     case variable(Token, Depth)
     case list(Token, [Expression])
     case tuple(Token, Expression, Expression, Expression)
-    case object(Expression, Token, [(Argument)])
+    case constructor(Expression, Token, [(Argument)])
 
     var locationToken: Token {
         switch self {
+        case .binary(_, let operToken, _):
+            return operToken
         case .unary(let locToken, _):
             return locToken
         case .literal(let valueToken, _):
@@ -30,7 +33,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return leftBracketToken
         case .tuple(let leftParenToken, _, _, _):
             return leftParenToken
-        case .object(_, let leftParenToken, _):
+        case .constructor(_, let leftParenToken, _):
             return leftParenToken
         }
     }

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -11,6 +11,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
         public var value: Expression<Depth>
     }
 
+    case unary(Token, Expression)
     case literal(Token, ScintillaValue)
     case variable(Token, Depth)
     case list(Token, [Expression])
@@ -19,6 +20,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
 
     var locationToken: Token {
         switch self {
+        case .unary(let locToken, _):
+            return locToken
         case .literal(let valueToken, _):
             return valueToken
         case .variable(let nameToken, _):

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -1,0 +1,34 @@
+//
+//  Expression.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/23/25.
+//
+
+indirect enum Expression<Depth: Equatable>: Equatable {
+    public struct Argument: Equatable {
+        public var name: Token
+        public var value: Expression<Depth>
+    }
+
+    case literal(Token, ScintillaValue)
+    case variable(Token, Depth)
+    case list(Token, [Expression])
+    case tuple(Token, Expression, Expression, Expression)
+    case object(Expression, Token, [(Argument)])
+
+    var locationToken: Token {
+        switch self {
+        case .literal(let valueToken, _):
+            return valueToken
+        case .variable(let nameToken, _):
+            return nameToken
+        case .list(let leftBracketToken, _):
+            return leftBracketToken
+        case .tuple(let leftParenToken, _, _, _):
+            return leftParenToken
+        case .object(_, let leftParenToken, _):
+            return leftParenToken
+        }
+    }
+}

--- a/ScintillaApp/ParseError.swift
+++ b/ScintillaApp/ParseError.swift
@@ -1,0 +1,43 @@
+//
+//  ParseError.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/23/25.
+//
+
+import Foundation
+
+enum ParseError: CustomStringConvertible, LocalizedError {
+    case missingVariableName(Token)
+    case missingEquals(Token)
+    case missingLeftParen(Token)
+    case missingRightParen(Token)
+    case missingRightBracket(Token)
+    case missingColon(Token)
+    case missingComma(Token)
+    case missingIdentifier(Token)
+    case expectedExpression(Token)
+
+    var description: String {
+        switch self {
+        case .missingVariableName(let token):
+            return "[\(token.location)] Error: expected variable name"
+        case .missingEquals(let token):
+            return "[\(token.location)] Error: expected equals sign in let statement"
+        case .missingLeftParen(let token):
+            return "[\(token.location)] Error: expected left parenthesis"
+        case .missingRightParen(let token):
+            return "[\(token.location)] Error: expected right parenthesis"
+        case .missingRightBracket(let token):
+            return "[\(token.location)] Error: expected right bracket"
+        case .missingColon(let token):
+            return "[\(token.location)] Error: expected colon"
+        case .missingComma(let token):
+            return "[\(token.location)] Error: expected comma"
+        case .missingIdentifier(let token):
+            return "[\(token.location)] Error: expected an identifier"
+        case .expectedExpression(let token):
+            return "[\(token.location)] Error: expected an expression"
+        }
+    }
+}

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -161,7 +161,6 @@ extension Parser {
         return expr
     }
 
-    // TODO: Think of a better name for this... maybe constructor
     mutating private func parseConstructor(expr: Expression<UnresolvedDepth>) throws -> Expression<UnresolvedDepth>? {
         guard let leftParen = consumeToken(type: .leftParen) else {
             return nil

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -70,7 +70,7 @@ extension Parser {
     //    program        → statement* EOF ;
     //    statement      → letDecl
     //                   | expression ;
-    //    letDecl        → "let" IDENTIFIER ( "=" expression )? ;
+    //    letDecl        → "let" IDENTIFIER "=" expression ;
     //    expression     → term ;
     //    term           → factor ( ( "-" | "+" ) factor )* ;
     //    factor         → unary ( ( "/" | "*" | "%" ) unary )* ;

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -110,7 +110,7 @@ extension Parser {
             return .literal(previousToken, .double(value))
         }
 
-        if let expr = try parsePostfix() {
+        if let expr = try parseUnary() {
             return expr
         }
 
@@ -123,6 +123,18 @@ extension Parser {
         }
 
         throw ParseError.expectedExpression(currentToken)
+    }
+
+    mutating private func parseUnary() throws -> Expression<UnresolvedDepth>? {
+        // NOTA BENE: For the time being, the onky unary expression allowed is
+        // one that involves a single minus sign.
+        if currentTokenMatchesAny(types: [.minus]) {
+            let oper = previousToken
+            let expr = try parseExpression()
+            return .unary(oper, expr)
+        }
+
+        return try parsePostfix()
     }
 
     mutating private func parsePostfix() throws -> Expression<UnresolvedDepth>? {

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -1,0 +1,211 @@
+//
+//  Parser.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/23/25.
+//
+
+struct Parser {
+    private var tokens: [Token]
+    private var cursor: Int = 0
+    private var currentToken: Token {
+        return tokens[cursor]
+    }
+    private var previousToken: Token {
+        return tokens[cursor - 1]
+    }
+
+    init(tokens: [Token]) {
+        self.tokens = tokens
+    }
+}
+
+extension Parser {
+    mutating private func advanceCursor() {
+        cursor += 1
+    }
+
+    private func currentTokenMatches(type: TokenType) -> Bool {
+        if currentToken.type == .eof {
+            return false
+        }
+
+        return currentToken.type == type
+    }
+
+    mutating private func currentTokenMatchesAny(types: [TokenType]) -> Bool {
+        for type in types {
+            if currentTokenMatches(type: type) {
+                advanceCursor()
+                return true
+            }
+        }
+
+        return false
+    }
+
+    mutating private func consumeToken(type: TokenType) -> Token? {
+        guard currentTokenMatches(type: type) else {
+            return nil
+        }
+
+        advanceCursor()
+        return previousToken
+    }
+}
+
+extension Parser {
+    mutating func parse() throws -> [Statement<UnresolvedDepth>] {
+        var statements: [Statement<UnresolvedDepth>] = []
+        while currentToken.type != .eof {
+            let statement = try parseStatement()
+            statements.append(statement)
+        }
+
+        return statements
+    }
+
+    // Statements are parsed in the following order:
+    //
+    //    program        → statement* EOF ;
+    //    statement      → letDecl
+    //                   | expression ;
+    //    letDecl        → "let" IDENTIFIER ( "=" expression )? ;
+    //    expression     → number
+    //                   | object
+    //                   | variable
+    //                   | tuple
+    //                   | list ;
+
+    mutating func parseStatement() throws -> Statement<UnresolvedDepth> {
+        if let letDecl = try parseLetDeclaration() {
+            return letDecl
+        }
+
+        let expression = try parseExpression()
+        return .expression(expression)
+    }
+
+    mutating private func parseLetDeclaration() throws -> Statement<UnresolvedDepth>? {
+        guard currentTokenMatchesAny(types: [.let]) else {
+            return nil
+        }
+
+        guard let varName = consumeToken(type: .identifier) else {
+            throw ParseError.missingVariableName(currentToken)
+        }
+
+        guard currentTokenMatchesAny(types: [.equal]) else {
+            throw ParseError.missingEquals(currentToken)
+        }
+
+        let letExpr = try parseExpression()
+
+        return .letDeclaration(varName, letExpr);
+    }
+
+    mutating private func parseExpression() throws -> Expression<UnresolvedDepth> {
+        if let number = consumeToken(type: .double) {
+            let value = Double(number.lexeme)!
+            return .literal(previousToken, .double(value))
+        }
+
+        if let expr = try parsePostfix() {
+            return expr
+        }
+
+        if let tuple = try parseTuple() {
+            return tuple
+        }
+
+        if let list = try parseList() {
+            return list
+        }
+
+        throw ParseError.expectedExpression(currentToken)
+    }
+
+    mutating private func parsePostfix() throws -> Expression<UnresolvedDepth>? {
+        guard let varName = consumeToken(type: .identifier) else {
+            return nil
+        }
+        var expr:Expression<UnresolvedDepth> = .variable(varName, UnresolvedDepth())
+
+        if let object = try parseObject(expr: expr) {
+            expr = object
+        }
+
+        return expr
+    }
+
+    mutating private func parseObject(expr: Expression<UnresolvedDepth>) throws -> Expression<UnresolvedDepth>? {
+        guard let leftParen = consumeToken(type: .leftParen) else {
+            return nil
+        }
+
+        var argList: [Expression<UnresolvedDepth>.Argument] = []
+        if currentToken.type != .rightParen {
+            repeat {
+                guard let argName = consumeToken(type: .identifier) else {
+                    throw ParseError.missingIdentifier(currentToken)
+                }
+
+                guard currentTokenMatchesAny(types: [.colon]) else {
+                    throw ParseError.missingColon(currentToken)
+                }
+
+                let argValue = try parseExpression()
+                let newArg = Expression<UnresolvedDepth>.Argument(name: argName, value: argValue)
+                argList.append(newArg)
+            } while currentTokenMatchesAny(types: [.comma])
+        }
+
+        guard currentTokenMatchesAny(types: [.rightParen]) else {
+            throw ParseError.missingRightParen(currentToken)
+        }
+
+        return .object(expr, leftParen, argList)
+    }
+
+    mutating private func parseTuple() throws -> Expression<UnresolvedDepth>? {
+        guard let leftParen = consumeToken(type: .leftParen) else {
+            return nil
+        }
+
+        let expr0 = try parseExpression()
+        guard currentTokenMatchesAny(types: [.comma]) else {
+            throw ParseError.missingComma(currentToken)
+        }
+
+        let expr1 = try parseExpression()
+        guard currentTokenMatchesAny(types: [.comma]) else {
+            throw ParseError.missingComma(currentToken)
+        }
+
+        let expr2 = try parseExpression()
+
+        guard currentTokenMatchesAny(types: [.rightParen]) else {
+            throw ParseError.missingRightParen(currentToken)
+        }
+
+        return .tuple(leftParen, expr0, expr1, expr2)
+    }
+
+    mutating private func parseList() throws -> Expression<UnresolvedDepth>? {
+        guard let leftBracket = consumeToken(type: .leftBracket) else {
+            return nil
+        }
+
+        var exprList: [Expression<UnresolvedDepth>] = []
+        repeat {
+            let newExpr = try parseExpression()
+            exprList.append(newExpr)
+        } while currentTokenMatchesAny(types: [.comma])
+
+        guard currentTokenMatchesAny(types: [.rightBracket]) else {
+            throw ParseError.missingRightBracket(currentToken)
+        }
+
+        return .list(leftBracket, exprList)
+    }
+}

--- a/ScintillaApp/ScintillaApp.swift
+++ b/ScintillaApp/ScintillaApp.swift
@@ -35,8 +35,10 @@ struct ScintillaApp: App {
             var tokenizer = Tokenizer(source: document.text)
             do {
                 let tokens = try tokenizer.scanTokens()
-                for token in tokens {
-                    print(token)
+                var parser = Parser(tokens: tokens)
+                let statements = try parser.parse()
+                for statement in statements {
+                    print(statement)
                 }
             } catch {
                 print(error)

--- a/ScintillaApp/ScintillaApp.swift
+++ b/ScintillaApp/ScintillaApp.swift
@@ -37,10 +37,8 @@ struct ScintillaApp: App {
                 let tokens = try tokenizer.scanTokens()
                 var parser = Parser(tokens: tokens)
                 let statements = try parser.parse()
-                for statement in statements {
-                    print(statement)
-                }
             } catch {
+                // TODO: Need to expose error in app somehow
                 print(error)
             }
         }

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -1,0 +1,10 @@
+//
+//  ScintillaValue.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/23/25.
+//
+
+enum ScintillaValue: Equatable {
+    case double(Double)
+}

--- a/ScintillaApp/Statement.swift
+++ b/ScintillaApp/Statement.swift
@@ -1,0 +1,20 @@
+//
+//  Statement.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/23/25.
+//
+
+enum Statement<Depth: Equatable>: Equatable {
+    case letDeclaration(Token, Expression<Depth>?)
+    case expression(Expression<Depth>)
+
+    var locationToken: Token {
+        switch self {
+        case .letDeclaration(let nameToken, _):
+            return nameToken
+        case .expression(let expr):
+            return expr.locationToken
+        }
+    }
+}

--- a/ScintillaApp/TokenType.swift
+++ b/ScintillaApp/TokenType.swift
@@ -27,7 +27,6 @@ enum TokenType: Equatable {
     // Literals
     case identifier
     case double
-    case int
 
     // Keywords
     case `let`

--- a/ScintillaApp/Tokenizer.swift
+++ b/ScintillaApp/Tokenizer.swift
@@ -13,7 +13,7 @@ struct Tokenizer {
     private var currentIndex: String.Index
 
     let keywords: [String: TokenType] = [
-        "and": .let,
+        "let": .let,
     ]
 
     init(source: String) {
@@ -164,7 +164,7 @@ struct Tokenizer {
     mutating private func handleNumber() throws {
         try repeatedly { tryScan(where: \.isLoxDigit) }
 
-        var tokenType: TokenType = .int
+        var tokenType: TokenType = .double
         if tryScan(".") {
             tokenType = .double
 

--- a/ScintillaApp/UnresolvedDepth.swift
+++ b/ScintillaApp/UnresolvedDepth.swift
@@ -1,0 +1,11 @@
+//
+//  UnresolvedDepth.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/23/25.
+//
+
+// NOTA BENE: This struct is used in the parsing stage so that we
+// can later use that same AST in the resolver with _actual_ depths
+struct UnresolvedDepth: Equatable {
+}


### PR DESCRIPTION
This is a first cut at a parser for the tiny Scintilla language. For now, its grammar is the following:

```
    program        → statement* EOF ;
    statement      → letDecl
                   | expression ;
    letDecl        → "let" IDENTIFIER "=" expression ;
    expression     → term ;
    term           → factor ( ( "-" | "+" ) factor )* ;
    factor         → unary ( ( "/" | "*" | "%" ) unary )* ;
    unary          → ( "!" | "-" | "*" ) unary
                   | postfix ;
    postfix        → primary
                   | constructor
    constructor    → IDENTIFIER ( (IDENTIFIER : expression)* ) ;
    primary        → tuple
                   | list
                   | double
                   | IDENTIFIER ;
```

The implementation, like that for the tokenizer, was also based largely on that for my slox language, but since this little language is much smaller than slox, the grammar and the parser logic is significantly less complex. 

There was also a tiny bug in the tokenizer that has been addressed in this PR.