### PR TITLE
Introduced `Program` into grammar

### DIFF
--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -55,14 +55,15 @@ extension Parser {
 }
 
 extension Parser {
-    mutating func parse() throws -> [Statement<UnresolvedDepth>] {
+    mutating func parse() throws -> Program<UnresolvedDepth> {
         var statements: [Statement<UnresolvedDepth>] = []
-        while currentToken.type != .eof {
-            let statement = try parseStatement()
+        while let statement = try parseStatement() {
             statements.append(statement)
         }
 
-        return statements
+        let finalExpression = try parseExpression()
+
+        return Program(statements: statements, finalExpression: finalExpression)
     }
 
     // Scintilla programs are parsed in the following order:
@@ -82,13 +83,12 @@ extension Parser {
     //                   | constructor ;
     //    constructor    → IDENTIFIER ( (IDENTIFIER : expression)* ) ;
 
-    mutating func parseStatement() throws -> Statement<UnresolvedDepth> {
+    mutating func parseStatement() throws -> Statement<UnresolvedDepth>? {
         if let letDecl = try parseLetDeclaration() {
             return letDecl
         }
 
-        let expression = try parseExpression()
-        return .expression(expression)
+        return nil
     }
 
     mutating private func parseLetDeclaration() throws -> Statement<UnresolvedDepth>? {

--- a/ScintillaApp/Program.swift
+++ b/ScintillaApp/Program.swift
@@ -1,0 +1,11 @@
+//
+//  Program.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/28/25.
+//
+
+struct Program<Depth: Equatable> {
+    public var statements: [Statement<Depth>]
+    public var finalExpression: Expression<Depth>
+}

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -98,11 +98,14 @@ extension Resolver {
 
 extension Resolver {
     // Main point of entry
-    mutating func resolve(statements: [Statement<UnresolvedDepth>]) throws -> [Statement<Int>] {
-        let resolvedStatements = try statements.map { statement in
+    mutating func resolve(program: Program<UnresolvedDepth>) throws -> Program<Int> {
+        let resolvedStatements = try program.statements.map { statement in
             return try resolve(statement: statement)
         }
-        return resolvedStatements
+
+        let resolvedFinalExpression = try resolve(expression: program.finalExpression)
+
+        return Program(statements: resolvedStatements, finalExpression: resolvedFinalExpression)
     }
 
     private mutating func resolve(statement: Statement<UnresolvedDepth>) throws -> Statement<Int> {

--- a/ScintillaApp/ScintillaApp.swift
+++ b/ScintillaApp/ScintillaApp.swift
@@ -35,7 +35,6 @@ struct ScintillaApp: App {
     }
 
     private func renderScene() async {
-        print("Rendering scene...")
         if let document {
             do {
                 let evaluator = Evaluator()
@@ -47,7 +46,6 @@ struct ScintillaApp: App {
                 // to view it
                 let downloadsDir = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
                 let newFileUrl = downloadsDir.appending(path: "test.png")
-                FileManager.default.createFile(atPath: newFileUrl.path(), contents: nil, attributes: nil)
                 canvas.save(to: newFileUrl.path())
 
                 let cgImage = canvas.toCGImage()

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -32,6 +32,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
         case (.camera(let l), .camera(let r)):
             return l == r
         case (.light(let l), .light(let r)):
+            // TODO: Move this into a standalone function in ScintillaLib
             if let l = l as? PointLight, let r = r as? PointLight {
                 return l == r
             } else if let l = l as? AreaLight, let r = r as? AreaLight {


### PR DESCRIPTION
The title of the PR kinda speaks for itself; there is a new struct. `Program`. along with changes to the parser, resolver, and evaluator that enforce the structure of a Scintilla program, namely that there can be zero or more `Statement`s and a single terminal expression that _must_ evaluate to a `World` object. 