### PR TITLE
Introduce support for shape modifiers

### DIFF
--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -40,9 +40,10 @@ extension CodeEditor {
     }
 
     private func highlightKeywords(textStorage: NSTextStorage) {
+        // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane/
+        let shapeKeywords = /ParametricSurface|Plane|Cube|Sphere/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),
@@ -52,7 +53,6 @@ extension CodeEditor {
         for (regex, color) in regexColorMappings {
             self.highlight(textStorage: textStorage, regex: regex, color: color)
         }
-
     }
 
     private func highlightParameterNames(textStorage: NSTextStorage) {

--- a/ScintillaApp/Environment.swift
+++ b/ScintillaApp/Environment.swift
@@ -32,6 +32,9 @@ class Environment: Equatable {
         case .functionName(let baseName, _):
             let location = baseName.location()
             throw RuntimeError.undefinedFunction(location, baseName)
+        case .methodName(_, let methodName, _):
+            let location = methodName.location()
+            throw RuntimeError.undefinedMethod(location, methodName)
         }
     }
 
@@ -49,6 +52,9 @@ class Environment: Equatable {
         case .functionName(let baseName, _):
             let location = baseName.location()
             throw RuntimeError.undefinedFunction(location, baseName)
+        case .methodName(_, let methodName, _):
+            let location = methodName.location()
+            throw RuntimeError.undefinedMethod(location, methodName)
         }
     }
 
@@ -68,6 +74,9 @@ class Environment: Equatable {
         case .functionName(let baseName, _):
             let location = baseName.location()
             throw RuntimeError.undefinedFunction(location, baseName)
+        case .methodName(_, let methodName, _):
+            let location = methodName.location()
+            throw RuntimeError.undefinedMethod(location, methodName)
         }
     }
 

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -189,6 +189,6 @@ class Evaluator {
 
         // TODO: Need to package up arguments such that names, locations, _and_ values
         // are all accessible within the call() function.
-        return try method.callMethod(callee: object, argumentValues: argumentValues)
+        return try method.callMethod(object: object, argumentValues: argumentValues)
     }
 }

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -17,7 +17,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case variable(Token, Depth)
     case list(Token, [Expression])
     case tuple(Token, Expression, Expression, Expression)
-    case function(Token, [(Argument)], Depth)
+    case function(Token, [Argument], Depth)
+    case method(Expression, Token, [Argument])
 
     var locationToken: Token {
         switch self {
@@ -35,6 +36,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return leftParenToken
         case .function(let nameToken, _, _):
             return nameToken
+        case .method(_, let methodNameToken, _):
+            return methodNameToken
         }
     }
 }

--- a/ScintillaApp/ObjectName.swift
+++ b/ScintillaApp/ObjectName.swift
@@ -8,4 +8,5 @@
 enum ObjectName: Hashable {
     case variableName(Substring)
     case functionName(Substring, [Substring])
+    case methodName(ScintillaType, Substring, [Substring])
 }

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum RuntimeError: LocalizedError, CustomStringConvertible {
     case undefinedVariable(Location, Substring)
     case undefinedFunction(Location, Substring)
+    case undefinedMethod(Location, Substring)
     case unsupportedUnaryOperator(Location, Substring)
     case unaryOperandMustBeNumber(Location, Substring)
     case unsupportedBinaryOperator(Location, Substring)
@@ -26,6 +27,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[\(location)] Error: undefined variable, \(name)"
         case .undefinedFunction(let location, let name):
             return "[\(location)] Error: undefined function, \(name)"
+        case .undefinedMethod(let location, let name):
+            return "[\(location)] Error: undefined method, \(name)"
         case .unsupportedUnaryOperator(let location, let badOperator):
             return "[\(location)] Error: unsupported unary operator, \(badOperator)"
         case .unaryOperandMustBeNumber(let location, let badOperator):

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -18,6 +18,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
     case notAFunction(Location, Substring)
     // TODO: Need to capture location and lexemes for the following three error cases
     case incorrectArgument
+    case incorrectObject
     case missingLastExpression
     case lastExpressionNeedsToBeWorld
 
@@ -41,6 +42,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[\(location)] Error: not a function, \(badFunction)"
         case .incorrectArgument:
             return "[] Error: bad argument"
+        case .incorrectObject:
+            return "[] Error: method does not exist on object"
         case .missingLastExpression:
             return "[] Error: missing last expression"
         case .lastExpressionNeedsToBeWorld:

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -19,6 +19,11 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
     // TODO: Need to capture location and lexemes for the following three error cases
     case incorrectArgument
     case incorrectObject
+    case expectedDouble
+    case expectedTuple
+    case expectedCamera
+    case expectedLight
+    case expectedShape
     case missingLastExpression
     case lastExpressionNeedsToBeWorld
 
@@ -42,6 +47,16 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[\(location)] Error: not a function, \(badFunction)"
         case .incorrectArgument:
             return "[] Error: bad argument"
+        case .expectedDouble:
+            return "[] Error: expected a double value for the argument"
+        case .expectedTuple:
+            return "[] Error: expected a tuple for the argument"
+        case .expectedCamera:
+            return "[] Error: expected a camera for the argument"
+        case .expectedLight:
+            return "[] Error: expected the argument to be a list of Lights"
+        case .expectedShape:
+            return "[] Error: expected the argument to be a list of Shapes"
         case .incorrectObject:
             return "[] Error: method does not exist on object"
         case .missingLastExpression:

--- a/ScintillaApp/ScintillaApp.swift
+++ b/ScintillaApp/ScintillaApp.swift
@@ -26,7 +26,12 @@ struct ScintillaApp: App {
                     if let document, let viewModel {
                         Task {
                             viewModel.showSheet = true
-                            try await viewModel.renderImage(source: document.text)
+                            // TODO: BLARGG... we need to surface errors in the UI here!
+                            do {
+                                try await viewModel.renderImage(source: document.text)
+                            } catch {
+                                print(error)
+                            }
                         }
                     }
                 }

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -9,6 +9,7 @@ import ScintillaLib
 
 enum ScintillaBuiltin: CaseIterable, Equatable {
     case cube
+    case plane
     case sphere
     case world
     case camera
@@ -26,6 +27,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         switch self {
         case .cube:
             return .functionName("Cube", [])
+        case .plane:
+            return .functionName("Plane", [])
         case .sphere:
             return .functionName("Sphere", [])
         case .world:
@@ -57,6 +60,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         switch self {
         case .cube:
             return .shape(Cube())
+        case .plane:
+            return .shape(Plane())
         case .sphere:
             return .shape(Sphere())
         case .camera:

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -147,10 +147,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     private func makeColorFunctionCall(object: ScintillaValue,
                                        argumentValues: [ScintillaValue],
                                        colorSpace: ColorSpace) throws -> ScintillaValue {
-        guard case .shape(let shape) = object else {
-            throw RuntimeError.incorrectObject
-        }
-
+        let shape = try extractRawShape(argumentValue: object)
         let (colorComponent0, colorComponent1, colorComponent2) = try extractRawTuple(argumentValue: argumentValues[0])
 
         let solidColor: Material = .solidColor(colorComponent0, colorComponent1, colorComponent2, colorSpace)
@@ -159,10 +156,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
     private func makeTranslate(object: ScintillaValue,
                                argumentValues: [ScintillaValue]) throws -> ScintillaValue {
-        guard case .shape(let shape) = object else {
-            throw RuntimeError.incorrectObject
-        }
-
+        let shape = try extractRawShape(argumentValue: object)
         let x = try extractRawDouble(argumentValue: argumentValues[0])
         let y = try extractRawDouble(argumentValue: argumentValues[1])
         let z = try extractRawDouble(argumentValue: argumentValues[2])
@@ -172,10 +166,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
     private func makeScale(object: ScintillaValue,
                            argumentValues: [ScintillaValue]) throws -> ScintillaValue {
-        guard case .shape(let shape) = object else {
-            throw RuntimeError.incorrectObject
-        }
-
+        let shape = try extractRawShape(argumentValue: object)
         let x = try extractRawDouble(argumentValue: argumentValues[0])
         let y = try extractRawDouble(argumentValue: argumentValues[1])
         let z = try extractRawDouble(argumentValue: argumentValues[2])
@@ -185,10 +176,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
     private func makeShear(object: ScintillaValue,
                            argumentValues: [ScintillaValue]) throws -> ScintillaValue {
-        guard case .shape(let shape) = object else {
-            throw RuntimeError.incorrectObject
-        }
-
+        let shape = try extractRawShape(argumentValue: object)
         let xy = try extractRawDouble(argumentValue: argumentValues[0])
         let xz = try extractRawDouble(argumentValue: argumentValues[1])
         let yx = try extractRawDouble(argumentValue: argumentValues[2])
@@ -227,10 +215,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     private func makeRotationCall(object: ScintillaValue,
                                   argumentValues: [ScintillaValue],
                                   rotationAxis: RotationAxis) throws -> ScintillaValue {
-        guard case .shape(let shape) = object else {
-            throw RuntimeError.incorrectObject
-        }
-
+        let shape = try extractRawShape(argumentValue: object)
         let theta = try extractRawDouble(argumentValue: argumentValues[0])
 
         return switch rotationAxis {
@@ -293,13 +278,17 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         }
 
         let shapes = try wrappedShapes.map { wrappedShape in
-            guard case .shape(let shape) = wrappedShape else {
-                throw RuntimeError.expectedShape
-            }
-
-            return shape
+            return try extractRawShape(argumentValue: wrappedShape)
         }
 
         return shapes
+    }
+
+    private func extractRawShape(argumentValue: ScintillaValue) throws -> any Shape {
+        guard case .shape(let shape) = argumentValue else {
+            throw RuntimeError.expectedShape
+        }
+
+        return shape
     }
 }

--- a/ScintillaApp/ScintillaType.swift
+++ b/ScintillaApp/ScintillaType.swift
@@ -1,0 +1,17 @@
+//
+//  ScintillaType.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/30/25.
+//
+
+enum ScintillaType {
+    case double
+    case list
+    case tuple
+    case function
+    case shape
+    case camera
+    case light
+    case world
+}

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -7,17 +7,6 @@
 
 import ScintillaLib
 
-enum ScintillaType {
-    case double
-    case list
-    case tuple
-    case function
-    case shape
-    case camera
-    case light
-    case world
-}
-
 enum ScintillaValue: Equatable, CustomStringConvertible {
     case double(Double)
     case list([ScintillaValue])

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -7,6 +7,17 @@
 
 import ScintillaLib
 
+enum ScintillaType {
+    case double
+    case list
+    case tuple
+    case function
+    case shape
+    case camera
+    case light
+    case world
+}
+
 enum ScintillaValue: Equatable, CustomStringConvertible {
     case double(Double)
     case list([ScintillaValue])
@@ -16,6 +27,27 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
     case camera(Camera)
     case light(Light)
     case world(World)
+
+    var type: ScintillaType {
+        switch self {
+        case .double:
+            return .double
+        case .list:
+            return .list
+        case .tuple:
+            return .tuple
+        case .function:
+            return .function
+        case .shape(_):
+            return .shape
+        case .camera(_):
+            return .camera
+        case .light(_):
+            return .light
+        case .world(_):
+            return .world
+        }
+    }
 
     static func == (lhs: ScintillaValue, rhs: ScintillaValue) -> Bool {
         switch (lhs, rhs) {


### PR DESCRIPTION
This PR adds support for using shape transformation modifiers, such as `translate(x: y: z)`, in the Scintilla language. In addition to proper syntax highlighting, the parser, resolver, and evaluator have all been updated. Such modifiers are now mapped to a new enum case for `ObjectName`, namely `methodName()` so that lookups can be performed. A new enum, `ScintillaType` is now incorporated into this case to identify which object type such methods are attached to. (Note that we can get away with this because all shapes have the same methods, and both lights also share their methods, and so there is no need to associate methods with each specific shape or light.) Implementations for each method were also added to `ScintillaBuiltin`, all routed through a new method, `callMethod()`.

Additionally, it should be noted that there was a significant amount of refactoring for the processing of argument values in `ScintillaBuiltin` to reduce the amount of duplicative boilerplate code.