### PR TITLE
ADD MOAR SHAPES

### DIFF
--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -43,7 +43,7 @@ extension CodeEditor {
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Sphere|Superellipsoid|Torus/
+        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Prism|Sphere|Superellipsoid|Torus/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),

--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -43,7 +43,7 @@ extension CodeEditor {
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cube|Sphere/
+        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Sphere/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),

--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -43,7 +43,7 @@ extension CodeEditor {
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Sphere/
+        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Sphere|Torus/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),

--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -43,7 +43,7 @@ extension CodeEditor {
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Sphere|Torus/
+        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Sphere|Superellipsoid|Torus/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),

--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -43,7 +43,7 @@ extension CodeEditor {
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Prism|Sphere|Superellipsoid|Torus/
+        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Prism|Sphere|Superellipsoid|SurfaceOfRevolution|Torus/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -77,10 +77,13 @@ class Evaluator {
             return try handleVariableExpression(varToken: varToken, depth: depth)
         case .list(_, let elements):
             return try handleListExpression(elements: elements)
-        case .tuple(_, let expr0, let expr1, let expr2):
-            return try handleTupleExpression(expr0: expr0,
-                                             expr1: expr1,
-                                             expr2: expr2)
+        case .tuple2(_, let expr0, let expr1):
+            return try handleTuple2Expression(expr0: expr0,
+                                              expr1: expr1)
+        case .tuple3(_, let expr0, let expr1, let expr2):
+            return try handleTuple3Expression(expr0: expr0,
+                                              expr1: expr1,
+                                              expr2: expr2)
         case .function(let calleeName, let arguments, _):
             return try handleFunction(calleeToken: calleeName,
                                       arguments: arguments)
@@ -143,14 +146,22 @@ class Evaluator {
         return .list(elementValues)
     }
 
-    private func handleTupleExpression(expr0: Expression<Int>,
-                                       expr1: Expression<Int>,
-                                       expr2: Expression<Int>) throws -> ScintillaValue {
+    private func handleTuple2Expression(expr0: Expression<Int>,
+                                        expr1: Expression<Int>) throws -> ScintillaValue {
+        let value0 = try evaluate(expr: expr0)
+        let value1 = try evaluate(expr: expr1)
+
+        return .tuple2((value0, value1))
+    }
+
+    private func handleTuple3Expression(expr0: Expression<Int>,
+                                        expr1: Expression<Int>,
+                                        expr2: Expression<Int>) throws -> ScintillaValue {
         let value0 = try evaluate(expr: expr0)
         let value1 = try evaluate(expr: expr1)
         let value2 = try evaluate(expr: expr2)
 
-        return .tuple((value0, value1, value2))
+        return .tuple3((value0, value1, value2))
     }
 
     private func handleFunction(calleeToken: Token,

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -16,7 +16,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case literal(Token, ScintillaValue)
     case variable(Token, Depth)
     case list(Token, [Expression])
-    case tuple(Token, Expression, Expression, Expression)
+    case tuple2(Token, Expression, Expression)
+    case tuple3(Token, Expression, Expression, Expression)
     case function(Token, [Argument], Depth)
     case method(Expression, Token, [Argument])
 
@@ -32,7 +33,9 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return nameToken
         case .list(let leftBracketToken, _):
             return leftBracketToken
-        case .tuple(let leftParenToken, _, _, _):
+        case .tuple2(let leftParenToken, _, _):
+            return leftParenToken
+        case .tuple3(let leftParenToken, _, _, _):
             return leftParenToken
         case .function(let nameToken, _, _):
             return nameToken

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -218,13 +218,14 @@ extension Parser {
         }
 
         let expr1 = try parseExpression()
-        guard currentTokenMatchesAny(types: [.comma]) else {
-            throw ParseError.missingComma(currentToken)
-        }
 
         if currentTokenMatches(type: .rightParen) {
             let _ = consumeToken(type: .rightParen)
             return .tuple2(leftParen, expr0, expr1)
+        }
+
+        guard currentTokenMatchesAny(types: [.comma]) else {
+            throw ParseError.missingComma(currentToken)
         }
 
         let expr2 = try parseExpression()

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -183,6 +183,14 @@ extension Parser {
             return list
         }
 
+        if currentTokenMatchesAny(types: [.false]) {
+            return .literal(previousToken, .boolean(false))
+        }
+
+        if currentTokenMatchesAny(types: [.true]) {
+            return .literal(previousToken, .boolean(true))
+        }
+
         if let number = consumeToken(type: .double) {
             let value = Double(number.lexeme)!
             return .literal(previousToken, .double(value))

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -222,13 +222,18 @@ extension Parser {
             throw ParseError.missingComma(currentToken)
         }
 
+        if currentTokenMatches(type: .rightParen) {
+            let _ = consumeToken(type: .rightParen)
+            return .tuple2(leftParen, expr0, expr1)
+        }
+
         let expr2 = try parseExpression()
 
         guard currentTokenMatchesAny(types: [.rightParen]) else {
             throw ParseError.missingRightParen(currentToken)
         }
 
-        return .tuple(leftParen, expr0, expr1, expr2)
+        return .tuple3(leftParen, expr0, expr1, expr2)
     }
 
     mutating private func parseList() throws -> Expression<UnresolvedDepth>? {

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -148,11 +148,15 @@ extension Resolver {
             return .literal(valueToken, value)
         case .list(let leftBracketToken, let elements):
             return try handleList(leftBracketToken: leftBracketToken, elements: elements)
-        case .tuple(let leftParenToken, let expr0, let expr1, let expr2):
-            return try handleTuple(leftParenToken: leftParenToken,
-                                   expr0: expr0,
-                                   expr1: expr1,
-                                   expr2: expr2)
+        case .tuple2(let leftParenToken, let expr0, let expr1):
+            return try handleTuple2(leftParenToken: leftParenToken,
+                                    expr0: expr0,
+                                    expr1: expr1)
+        case .tuple3(let leftParenToken, let expr0, let expr1, let expr2):
+            return try handleTuple3(leftParenToken: leftParenToken,
+                                    expr0: expr0,
+                                    expr1: expr1,
+                                    expr2: expr2)
         case .function(let calleeName, let arguments, _):
             return try handleFunction(calleeToken: calleeName,
                                       arguments: arguments)
@@ -204,10 +208,25 @@ extension Resolver {
         return .list(leftBracketToken, resolvedElements)
     }
 
-    mutating private func handleTuple(leftParenToken: Token,
-                                      expr0: Expression<UnresolvedDepth>,
-                                      expr1: Expression<UnresolvedDepth>,
-                                      expr2: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+    mutating private func handleTuple2(leftParenToken: Token,
+                                       expr0: Expression<UnresolvedDepth>,
+                                       expr1: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+        let previousArgumentListType = currentArgumentListType
+        currentArgumentListType = .tupleInitializer
+        defer {
+            currentArgumentListType = previousArgumentListType
+        }
+
+        let resolvedExpr0 = try resolve(expression: expr0)
+        let resolvedExpr1 = try resolve(expression: expr1)
+
+        return .tuple2(leftParenToken, resolvedExpr0, resolvedExpr1)
+    }
+
+    mutating private func handleTuple3(leftParenToken: Token,
+                                       expr0: Expression<UnresolvedDepth>,
+                                       expr1: Expression<UnresolvedDepth>,
+                                       expr2: Expression<UnresolvedDepth>) throws -> Expression<Int> {
         let previousArgumentListType = currentArgumentListType
         currentArgumentListType = .tupleInitializer
         defer {
@@ -218,7 +237,7 @@ extension Resolver {
         let resolvedExpr1 = try resolve(expression: expr1)
         let resolvedExpr2 = try resolve(expression: expr2)
 
-        return .tuple(leftParenToken, resolvedExpr0, resolvedExpr1, resolvedExpr2)
+        return .tuple3(leftParenToken, resolvedExpr0, resolvedExpr1, resolvedExpr2)
     }
 
     mutating private func handleFunction(calleeToken: Token,

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -19,6 +19,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
     // TODO: Need to capture location and lexemes for the following three error cases
     case incorrectArgument
     case incorrectObject
+    case expectedBoolean
     case expectedDouble
     case expectedTuple
     case expectedCamera
@@ -47,6 +48,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[\(location)] Error: not a function, \(badFunction)"
         case .incorrectArgument:
             return "[] Error: bad argument"
+        case .expectedBoolean:
+            return "[] Error: expected a boolean value for the argument"
         case .expectedDouble:
             return "[] Error: expected a double value for the argument"
         case .expectedTuple:

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -13,6 +13,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case cylinder
     case plane
     case sphere
+    case superellipsoid
     case torus
     case world
     case camera
@@ -38,6 +39,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("Plane", [])
         case .sphere:
             return .functionName("Sphere", [])
+        case .superellipsoid:
+            return .functionName("Superellipsoid", ["e", "n"])
         case .torus:
             return .functionName("Torus", ["majorRadius", "minorRadius"])
         case .world:
@@ -77,6 +80,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .shape(Plane())
         case .sphere:
             return .shape(Sphere())
+        case .superellipsoid:
+            return try makeSuperellipsoid(argumentValues: argumentValues)
         case .torus:
             return try makeTorus(argumentValues: argumentValues)
         case .camera:
@@ -129,6 +134,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
         let cylinder = Cylinder(bottomY: bottomY, topY: topY, isCapped: isCapped)
         return .shape(cylinder)
+    }
+
+    private func makeSuperellipsoid(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let e = try extractRawDouble(argumentValue: argumentValues[0])
+        let n = try extractRawDouble(argumentValue: argumentValues[1])
+
+        let superellipsoid = Superellipsoid(e: e, n: n)
+        return .shape(superellipsoid)
     }
 
     private func makeTorus(argumentValues: [ScintillaValue]) throws -> ScintillaValue {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -299,7 +299,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     }
 
     private func extractRawTuple(argumentValue: ScintillaValue) throws -> (Double, Double, Double) {
-        guard case .tuple(let tuple) = argumentValue else {
+        guard case .tuple3(let tuple) = argumentValue else {
             throw RuntimeError.expectedTuple
         }
 

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -10,6 +10,7 @@ import ScintillaLib
 enum ScintillaBuiltin: CaseIterable, Equatable {
     case cone
     case cube
+    case cylinder
     case plane
     case sphere
     case world
@@ -30,6 +31,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("Cone", ["bottomY", "topY", "isCapped"])
         case .cube:
             return .functionName("Cube", [])
+        case .cylinder:
+            return .functionName("Cylinder", ["bottomY", "topY", "isCapped"])
         case .plane:
             return .functionName("Plane", [])
         case .sphere:
@@ -65,6 +68,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return try makeCone(argumentValues: argumentValues)
         case .cube:
             return .shape(Cube())
+        case .cylinder:
+            return try makeCylinder(argumentValues: argumentValues)
         case .plane:
             return .shape(Plane())
         case .sphere:
@@ -110,6 +115,15 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
         let cone = Cone(bottomY: bottomY, topY: topY, isCapped: isCapped)
         return .shape(cone)
+    }
+
+    private func makeCylinder(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let bottomY = try extractRawDouble(argumentValue: argumentValues[0])
+        let topY = try extractRawDouble(argumentValue: argumentValues[1])
+        let isCapped = try extractRawBoolean(argumentValue: argumentValues[2])
+
+        let cylinder = Cylinder(bottomY: bottomY, topY: topY, isCapped: isCapped)
+        return .shape(cylinder)
     }
 
     private func makeWorld(argumentValues: [ScintillaValue]) throws -> ScintillaValue {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -15,6 +15,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case prism
     case sphere
     case superellipsoid
+    case surfaceOfRevolution
     case torus
     case world
     case camera
@@ -44,6 +45,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("Sphere", [])
         case .superellipsoid:
             return .functionName("Superellipsoid", ["e", "n"])
+        case .surfaceOfRevolution:
+            return .functionName("SurfaceOfRevolution", ["yzPoints", "isCapped"])
         case .torus:
             return .functionName("Torus", ["majorRadius", "minorRadius"])
         case .world:
@@ -87,6 +90,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .shape(Sphere())
         case .superellipsoid:
             return try makeSuperellipsoid(argumentValues: argumentValues)
+        case .surfaceOfRevolution:
+            return try makeSurfaceOfRevolution(argumentValues: argumentValues)
         case .torus:
             return try makeTorus(argumentValues: argumentValues)
         case .camera:
@@ -156,6 +161,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
         let superellipsoid = Superellipsoid(e: e, n: n)
         return .shape(superellipsoid)
+    }
+
+    private func makeSurfaceOfRevolution(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let yzPoints = try extractRawTuple2List(argumentValue: argumentValues[0])
+        let isCapped = try extractRawBoolean(argumentValue: argumentValues[1])
+
+        let sor = SurfaceOfRevolution(yzPoints: yzPoints, isCapped: isCapped)
+        return .shape(sor)
     }
 
     private func makeTorus(argumentValues: [ScintillaValue]) throws -> ScintillaValue {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -8,6 +8,7 @@
 import ScintillaLib
 
 enum ScintillaBuiltin: CaseIterable, Equatable {
+    case cone
     case cube
     case plane
     case sphere
@@ -25,6 +26,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
     var objectName: ObjectName {
         switch self {
+        case .cone:
+            return .functionName("Cone", ["bottomY", "topY", "isCapped"])
         case .cube:
             return .functionName("Cube", [])
         case .plane:
@@ -58,6 +61,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
     public func call(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
         switch self {
+        case .cone:
+            return try makeCone(argumentValues: argumentValues)
         case .cube:
             return .shape(Cube())
         case .plane:
@@ -96,6 +101,15 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         default:
             fatalError("Internal error: only method calls should ever get here")
         }
+    }
+
+    private func makeCone(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let bottomY = try extractRawDouble(argumentValue: argumentValues[0])
+        let topY = try extractRawDouble(argumentValue: argumentValues[1])
+        let isCapped = try extractRawBoolean(argumentValue: argumentValues[2])
+
+        let cone = Cone(bottomY: bottomY, topY: topY, isCapped: isCapped)
+        return .shape(cone)
     }
 
     private func makeWorld(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
@@ -226,6 +240,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         case .z:
             .shape(shape.rotateZ(theta))
         }
+    }
+
+    private func extractRawBoolean(argumentValue: ScintillaValue) throws -> Bool {
+        guard case .boolean(let rawBoolean) = argumentValue else {
+            throw RuntimeError.expectedBoolean
+        }
+
+        return rawBoolean
     }
 
     private func extractRawDouble(argumentValue: ScintillaValue) throws -> Double {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -13,6 +13,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case cylinder
     case plane
     case sphere
+    case torus
     case world
     case camera
     case pointLight
@@ -37,6 +38,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("Plane", [])
         case .sphere:
             return .functionName("Sphere", [])
+        case .torus:
+            return .functionName("Torus", ["majorRadius", "minorRadius"])
         case .world:
             return .functionName("World", ["camera", "lights", "shapes"])
         case .camera:
@@ -74,6 +77,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .shape(Plane())
         case .sphere:
             return .shape(Sphere())
+        case .torus:
+            return try makeTorus(argumentValues: argumentValues)
         case .camera:
             return try makeCamera(argumentValues: argumentValues)
         case .pointLight:
@@ -124,6 +129,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
         let cylinder = Cylinder(bottomY: bottomY, topY: topY, isCapped: isCapped)
         return .shape(cylinder)
+    }
+
+    private func makeTorus(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let majorRadius = try extractRawDouble(argumentValue: argumentValues[0])
+        let minorRadius = try extractRawDouble(argumentValue: argumentValues[1])
+
+        let torus = Torus(majorRadius: majorRadius, minorRadius: minorRadius)
+        return .shape(torus)
     }
 
     private func makeWorld(argumentValues: [ScintillaValue]) throws -> ScintillaValue {

--- a/ScintillaApp/ScintillaType.swift
+++ b/ScintillaApp/ScintillaType.swift
@@ -9,7 +9,8 @@ enum ScintillaType {
     case boolean
     case double
     case list
-    case tuple
+    case tuple2
+    case tuple3
     case function
     case shape
     case camera

--- a/ScintillaApp/ScintillaType.swift
+++ b/ScintillaApp/ScintillaType.swift
@@ -6,6 +6,7 @@
 //
 
 enum ScintillaType {
+    case boolean
     case double
     case list
     case tuple

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -8,6 +8,7 @@
 import ScintillaLib
 
 enum ScintillaValue: Equatable, CustomStringConvertible {
+    case boolean(Bool)
     case double(Double)
     case list([ScintillaValue])
     indirect case tuple((ScintillaValue, ScintillaValue, ScintillaValue))
@@ -19,6 +20,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
 
     var type: ScintillaType {
         switch self {
+        case .boolean:
+            return .boolean
         case .double:
             return .double
         case .list:
@@ -40,6 +43,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
 
     static func == (lhs: ScintillaValue, rhs: ScintillaValue) -> Bool {
         switch (lhs, rhs) {
+        case (.boolean(let l), .boolean(let r)):
+            return l == r
         case (.double(let l), .double(let r)):
             return l == r
         case (.list(let l), .list(let r)):
@@ -70,6 +75,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
 
     var description: String {
         switch self {
+        case .boolean(let value):
+            return "\(value)"
         case .double(let value):
             return "\(value)"
         case .list(let values):

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -11,7 +11,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
     case boolean(Bool)
     case double(Double)
     case list([ScintillaValue])
-    indirect case tuple((ScintillaValue, ScintillaValue, ScintillaValue))
+    indirect case tuple2((ScintillaValue, ScintillaValue))
+    indirect case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
     case function(ScintillaBuiltin)
     case shape(any Shape)
     case camera(Camera)
@@ -26,8 +27,10 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return .double
         case .list:
             return .list
-        case .tuple:
-            return .tuple
+        case .tuple2:
+            return .tuple2
+        case .tuple3:
+            return .tuple3
         case .function:
             return .function
         case .shape(_):
@@ -49,7 +52,9 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return l == r
         case (.list(let l), .list(let r)):
             return l == r
-        case (.tuple(let l), .tuple(let r)):
+        case (.tuple2(let l), .tuple2(let r)):
+            return l == r
+        case (.tuple3(let l), .tuple3(let r)):
             return l == r
         case (.function(let l), .function(let r)):
             return l == r
@@ -81,7 +86,9 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return "\(value)"
         case .list(let values):
             return values.map { "\($0)" }.joined(separator: ", ")
-        case .tuple(let values):
+        case .tuple2(let values):
+            return "(\(values.0), \(values.1))"
+        case .tuple3(let values):
             return "(\(values.0), \(values.1), \(values.2))"
         case .function(let builtin):
             return "\(builtin.objectName)"

--- a/ScintillaApp/TokenType.swift
+++ b/ScintillaApp/TokenType.swift
@@ -29,7 +29,9 @@ enum TokenType: Equatable {
     case double
 
     // Keywords
+    case `false`
     case `let`
+    case `true`
 
     // Used for bad tokens
     case unknown

--- a/ScintillaApp/Tokenizer.swift
+++ b/ScintillaApp/Tokenizer.swift
@@ -13,7 +13,9 @@ struct Tokenizer {
     private var currentIndex: String.Index
 
     let keywords: [String: TokenType] = [
+        "false": .false,
         "let": .let,
+        "true": .true,
     ]
 
     init(source: String) {


### PR DESCRIPTION
This was a _fairly_ straightforward PR in that I needed to add new cases to `ScintillaBuiltin` and new implementations for the construction of new shape types. However, I _did_ need to introduce a new boolean type to properly support the `Cone` and `Cylinder` types, and so that required changes from the tokenizer all the way to the evaluator. Additionally, I needed to be able to support tuples with two components, not just three, and so I needed to split the old `.tuple` case into `.tuple2` and `.tuple3`, as well as thread a series of changes from the parser through to the evaluator. I also needed to update `CodeEditor` to ensure that the new introduced shape types are highlighted in the editor correctly.