### PR TITLE
Support constructive solid geometry

### DIFF
--- a/ScintillaApp.xcodeproj/project.pbxproj
+++ b/ScintillaApp.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 			repositoryURL = "https://github.com/quephird/ScintillaLib";
 			requirement = {
 				kind = exactVersion;
-				version = 0.0.13;
+				version = 0.0.14;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ScintillaApp/CSG+makeCSG.swift
+++ b/ScintillaApp/CSG+makeCSG.swift
@@ -1,0 +1,20 @@
+//
+//  CSG+makeCSG.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 1/31/25.
+//
+
+import ScintillaLib
+
+// ACHTUNG!!! This may be a temporary implementation until if/when
+// ScintillaApp can somehow result builders
+extension CSG {
+    static func makeCSG(_ operation: Operation,
+                        _ baseShape: any Shape,
+                        _ rightShapes: [any Shape]) -> any Shape {
+        return rightShapes.reduce(baseShape) { partialResult, rightShape in
+            CSG(operation, partialResult, rightShape)
+        }
+    }
+}

--- a/ScintillaApp/CSG+makeCSG.swift
+++ b/ScintillaApp/CSG+makeCSG.swift
@@ -8,7 +8,7 @@
 import ScintillaLib
 
 // ACHTUNG!!! This may be a temporary implementation until if/when
-// ScintillaApp can somehow result builders
+// ScintillaApp can somehow produce result builders
 extension CSG {
     static func makeCSG(_ operation: Operation,
                         _ baseShape: any Shape,


### PR DESCRIPTION
This PR introduces support for constructive solid geometry, which allows for interesting possibilities such as taking the intersection of two overlapping spheres to form a lens-like shape. In order to do this properly and support the `let`ting out of shapes and using them multiple times in `World` or `CSG`, there needed to be a major bug fix to ScintillaLib first, and indeed this branch now uses the new version. 

Other than that, there are now three new transformation functions exposed on `Shape` and implemented in `ScintillaBuiltin`, as well as a temporary extension to `CSG` to allow a set of `[any Shape]` to be passed in instead of a `ShapeBuilder` since this app does not currently have a means to produce result builders.