### PR TITLE
First cut at showing errors in the UI

### DIFF
--- a/ScintillaApp/ScintillaApp.swift
+++ b/ScintillaApp/ScintillaApp.swift
@@ -13,10 +13,25 @@ struct ScintillaApp: App {
     @FocusedBinding(\.document) var document: ScintillaDocument?
     @FocusedBinding(\.viewModel) var viewModel: ViewModel?
 
+    var currentErrorMessage: String {
+        if let viewModel {
+            if let error = viewModel.currentEvaluatorError {
+                return "\(error)"
+            }
+        }
+
+        return ""
+    }
+
     var body: some Scene {
         DocumentGroup(newDocument: ScintillaDocument()) { file in
             ContentView(document: file.$document)
                 .focusedSceneValue(\.document, file.$document)
+            HStack {
+                Text(currentErrorMessage)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+            }
         }
         .commands {
             CommandGroup(after: .saveItem) {
@@ -25,9 +40,8 @@ struct ScintillaApp: App {
                 Button("Render Scene…") {
                     if let document, let viewModel {
                         Task {
-                            viewModel.showSheet = true
-                            // TODO: BLARGG... we need to surface errors in the UI here!
                             do {
+                                viewModel.currentEvaluatorError = nil
                                 try await viewModel.renderImage(source: document.text)
                             } catch {
                                 print(error)

--- a/ScintillaApp/ViewModel.swift
+++ b/ScintillaApp/ViewModel.swift
@@ -13,6 +13,7 @@ import ScintillaLib
 @Observable
 class ViewModel {
     var showSheet: Bool = false
+    var currentEvaluatorError: Error?
     var showFileExporter: Bool = false
     var renderedImage: CGImage?
 
@@ -21,9 +22,14 @@ class ViewModel {
 
     public func renderImage(source: String) async throws {
         let evaluator = Evaluator()
-        let world = try evaluator.interpret(source: source)
-        let canvas = await world.render(updateClosure: updateProgress)
-        self.renderedImage = canvas.toCGImage()
+        do {
+            let world = try evaluator.interpret(source: source)
+            self.showSheet = true
+            let canvas = await world.render(updateClosure: updateProgress)
+            self.renderedImage = canvas.toCGImage()
+        } catch {
+            self.currentEvaluatorError = error
+        }
     }
 
     private func updateProgress(_ percentRendered: Double, elapsedTime: Range<Date>) {


### PR DESCRIPTION
This is kinduva rough cut _but_ at least now when there is an error during the evaluation of the scene, it is captured in the `ViewModel`, its description displayed in a new `Text` component in the app, and the user can continue editing to resolve the problem. Previously, you had to force quit the app and restart it if any errors occurred, as well as look at the Xcode console to see the error message. This is at least a step in the right direction.