### PR TITLE
Support `Group` shape type

### DIFF
--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -43,7 +43,7 @@ extension CodeEditor {
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
         let cameraKeyword = /Camera/
         let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Prism|Sphere|Superellipsoid|SurfaceOfRevolution|Torus/
+        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Group|Prism|Sphere|Superellipsoid|SurfaceOfRevolution|Torus/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),

--- a/ScintillaApp/Group+init.swift
+++ b/ScintillaApp/Group+init.swift
@@ -1,0 +1,20 @@
+//
+//  Group+init.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 2/3/25.
+//
+
+import ScintillaLib
+
+// ACHTUNG!!! This may be a temporary implementation until if/when
+// ScintillaApp can somehow produce result builders
+extension Group {
+    init(children: [any Shape]) {
+        self.init() {
+            for child in children {
+                child
+            }
+        }
+    }
+}

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -11,6 +11,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case cone
     case cube
     case cylinder
+    case group
     case plane
     case prism
     case sphere
@@ -40,6 +41,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("Cube", [])
         case .cylinder:
             return .functionName("Cylinder", ["bottomY", "topY", "isCapped"])
+        case .group:
+            return .functionName("Group", ["children"])
         case .plane:
             return .functionName("Plane", [])
         case .prism:
@@ -91,6 +94,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .shape(Cube())
         case .cylinder:
             return try makeCylinder(argumentValues: argumentValues)
+        case .group:
+            return try makeGroup(argumentValues: argumentValues)
         case .plane:
             return .shape(Plane())
         case .prism:
@@ -165,6 +170,13 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
 
         let cylinder = Cylinder(bottomY: bottomY, topY: topY, isCapped: isCapped)
         return .shape(cylinder)
+    }
+
+    private func makeGroup(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let children = try extractRawShapeList(argumentValue: argumentValues[0])
+
+        let group = Group(children: children)
+        return .shape(group)
     }
 
     private func makePrism(argumentValues: [ScintillaValue]) throws -> ScintillaValue {


### PR DESCRIPTION
This was about as straightforward as the set of changes needed to support `CSG` shapes. Likewise, I needed to create a local extension for `Group` to (temporarily) expose a new initializer that takes an array of `[any Shape]`, constructs a result builder from it, and passes that to the extant initializer native to the library. And the changes to `ScintillaBuiltin` and `CodeEditor` were analogous to those made to support `CSG`. 