### PR TITLE
Add parametric surface

### DIFF
--- a/ScintillaApp/Environment.swift
+++ b/ScintillaApp/Environment.swift
@@ -7,46 +7,28 @@
 
 class Environment: Equatable {
     var enclosingEnvironment: Environment?
-    private var values: [ObjectName: ScintillaValue] = [:]
+    private var values: [ScintillaValue] = []
+    private var names: [ObjectName: Int] = [:]
 
     init(enclosingEnvironment: Environment? = nil) {
         self.enclosingEnvironment = enclosingEnvironment
     }
 
     func define(name: ObjectName, value: ScintillaValue) {
-        values[name] = value
+        values.append(value)
+        names[name] = values.count - 1
     }
 
     func undefineAll() {
         values.removeAll(keepingCapacity: true)
+        names.removeAll(keepingCapacity: true)
     }
 
-    func assignAtDepth(name: ObjectName, value: ScintillaValue, depth: Int) throws {
-        let ancestor = try ancestor(depth: depth)
+    func getValueAtLocation(name: ObjectName, location: ResolvedLocation) throws -> ScintillaValue {
+        let ancestor = try ancestor(depth: location.depth)
 
-        if ancestor.values.keys.contains(name) {
-            ancestor.values[name] = value
-            return
-        }
-
-        switch name {
-        case .variableName(let variableName):
-            let location = variableName.location()
-            throw RuntimeError.undefinedVariable(location, variableName)
-        case .functionName(let baseName, _):
-            let location = baseName.location()
-            throw RuntimeError.undefinedFunction(location, baseName)
-        case .methodName(_, let methodName, _):
-            let location = methodName.location()
-            throw RuntimeError.undefinedMethod(location, methodName)
-        }
-    }
-
-    func getValueAtDepth(name: ObjectName, depth: Int) throws -> ScintillaValue {
-        let ancestor = try ancestor(depth: depth)
-
-        if let value = ancestor.values[name] {
-            return value
+        if location.index < ancestor.values.count {
+            return ancestor.values[location.index]
         }
 
         switch name {
@@ -63,8 +45,8 @@ class Environment: Equatable {
     }
 
     func getValue(name: ObjectName) throws -> ScintillaValue {
-        if let value = values[name] {
-            return value
+        if let index = names[name] {
+            return values[index]
         }
 
         if let enclosingEnvironment {

--- a/ScintillaApp/Environment.swift
+++ b/ScintillaApp/Environment.swift
@@ -18,7 +18,7 @@ class Environment: Equatable {
         self.values.reserveCapacity(capacity)
     }
 
-    func define(name: ObjectName, value: ScintillaValue) {
+    func define(name: ObjectName, value: consuming ScintillaValue) {
         values.append(value)
 
         // We only need the names dictionary for methods;

--- a/ScintillaApp/Environment.swift
+++ b/ScintillaApp/Environment.swift
@@ -14,6 +14,10 @@ class Environment: Equatable {
         self.enclosingEnvironment = enclosingEnvironment
     }
 
+    public func reserveCapacity(capacity: Int) {
+        self.values.reserveCapacity(capacity)
+    }
+
     func define(name: ObjectName, value: ScintillaValue) {
         values.append(value)
 

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -213,16 +213,7 @@ class Evaluator {
     private func handleFunction(calleeToken: Token,
                                 argumentNameTokens: [Token?],
                                 location: ResolvedLocation) throws -> ScintillaValue {
-        let baseName = calleeToken.lexeme
-        let argumentNames = argumentNameTokens.map { maybeNameToken in
-            if let nameToken = maybeNameToken  {
-                return nameToken.lexeme
-            }
-
-            return ""
-        }
-        let calleeName: ObjectName = .functionName(baseName, argumentNames)
-        let callee = try environment.getValueAtLocation(name: calleeName, location: location)
+        let callee = try environment.getValueAtLocation(location: location)
 
         guard callee.isCallable else {
             throw RuntimeError.notAFunction(calleeToken.location, calleeToken.lexeme)

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -307,7 +307,7 @@ class Evaluator {
                                       letDecls: [],
                                       returnExpr: expression)
 
-        return .implicitSurfaceLambda(udf)
+        return .lambda(udf)
     }
 
     private func handleMethod(calleeExpr: Expression<ResolvedLocation>,

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -149,6 +149,8 @@ class Evaluator {
             return try handleBinaryExpression(leftExpr: leftExpr, oper: oper, rightExpr: rightExpr)
         case .call(let calleeExpr, _, let arguments):
             return try handleCallDouble(calleeExpr: calleeExpr, arguments: arguments)
+        case .variable(let name, let location):
+            return try handleVariableExpressionDouble(varToken: name, location: location)
         default:
             let result = try evaluate(expr: expr)
 
@@ -193,6 +195,14 @@ class Evaluator {
 
     private func handleVariableExpression(varToken: Token, location: ResolvedLocation) throws -> ScintillaValue {
         return try environment.getValueAtLocation(location: location)
+    }
+
+    private func handleVariableExpressionDouble(varToken: Token, location: ResolvedLocation) throws -> Double {
+        let result = try environment.getValueAtLocation(location: location)
+        guard case .double(let double) = result else {
+            throw RuntimeError.expectedDouble
+        }
+        return double
     }
 
     private func handleListExpression(elements: [Expression<ResolvedLocation>]) throws -> ScintillaValue {

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -267,6 +267,17 @@ class Evaluator {
         case .builtin(.tanFunc):
             let arg = try evaluateDouble(expr: arguments[0].value)
             return tan(arg)
+        case .userDefinedFunction(let udf) where arguments.count <= 3:
+            func extract(at i: Int) throws -> Double {
+                guard i < arguments.count else { return 0.0 }
+                return try evaluateDouble(expr: arguments[i].value)
+            }
+
+            let a1 = try extract(at: 0)
+            let a2 = try extract(at: 1)
+            let a3 = try extract(at: 2)
+
+            return try udf.call(evaluator: self, argumentValues: a1, a2, a3)
         default:
             let result = try handleCall(calleeExpr: calleeExpr,
                                         arguments: arguments)

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -5,16 +5,16 @@
 //  Created by Danielle Kefford on 1/23/25.
 //
 
-indirect enum Expression<Depth: Equatable>: Equatable {
+indirect enum Expression<Location: Equatable>: Equatable {
     public struct Argument: Equatable {
         public var name: Token?
-        public var value: Expression<Depth>
+        public var value: Expression<Location>
     }
 
     case binary(Expression, Token, Expression)
     case unary(Token, Expression)
     case literal(Token, ScintillaValue)
-    case variable(Token, Depth)
+    case variable(Token, Location)
     case list(Token, [Expression])
     case tuple2(Token, Expression, Expression)
     case tuple3(Token, Expression, Expression, Expression)
@@ -23,7 +23,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     // * Builtin constructors of Scintilla objects, such as `Camera`, `ImplicitSurface`, etc.
     // * Native standalone functions "registered" in the environment, such as `sin()`, `cos()`, etc.
     // * User-defined functions
-    case function(Token, [Token?], Depth)
+    case function(Token, [Token?], Location)
     // ... whereas this case handles only one kind of object:
     //
     // * Builtin methods of Scintilla objects, such as `Shape.translate()`, `Shape.rotateX()`, etc.

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -13,7 +13,8 @@ indirect enum Expression<Location: Equatable>: Equatable {
 
     case binary(Expression, Token, Expression)
     case unary(Token, Expression)
-    case literal(Token, ScintillaValue)
+    case boolLiteral(Token, Bool)
+    case doubleLiteral(Token, Double)
     case variable(Token, Location)
     case list(Token, [Expression])
     case tuple2(Token, Expression, Expression)
@@ -37,7 +38,9 @@ indirect enum Expression<Location: Equatable>: Equatable {
             return operToken
         case .unary(let locToken, _):
             return locToken
-        case .literal(let valueToken, _):
+        case .boolLiteral(let valueToken, _):
+            return valueToken
+        case .doubleLiteral(let valueToken, _):
             return valueToken
         case .variable(let nameToken, _):
             return nameToken

--- a/ScintillaApp/ObjectName.swift
+++ b/ScintillaApp/ObjectName.swift
@@ -33,7 +33,7 @@ extension ObjectName: CustomStringConvertible {
 }
 
 extension ObjectName {
-    public func location() -> Location {
+    public func location() -> SourceLocation {
         switch self {
         case .variableName(let name):
             return name.location()

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -271,16 +271,16 @@ extension Parser {
         }
 
         if currentTokenMatchesAny(types: [.false]) {
-            return .literal(previousToken, .boolean(false))
+            return .boolLiteral(previousToken, false)
         }
 
         if currentTokenMatchesAny(types: [.true]) {
-            return .literal(previousToken, .boolean(true))
+            return .boolLiteral(previousToken, true)
         }
 
         if let number = consumeToken(type: .double) {
             let value = Double(number.lexeme)!
-            return .literal(previousToken, .double(value))
+            return .doubleLiteral(previousToken, value)
         }
 
         if let lambda = try parseLambda() {

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -15,6 +15,14 @@ struct Parser {
         return tokens[cursor - 1]
     }
 
+    private var nextToken: Token? {
+        if cursor < tokens.count - 1 {
+            return tokens[cursor + 1]
+        }
+
+        return nil
+    }
+
     init(tokens: [Token]) {
         self.tokens = tokens
     }
@@ -373,7 +381,8 @@ extension Parser {
         if currentToken.type != .rightParen {
             repeat {
                 var argName: Token? = nil
-                if let consumedToken = consumeToken(type: .identifier) {
+                if case .colon? = nextToken?.type,
+                   let consumedToken = consumeToken(type: .identifier) {
                     argName = consumedToken
 
                     guard currentTokenMatchesAny(types: [.colon]) else {

--- a/ScintillaApp/ResolvedLocation.swift
+++ b/ScintillaApp/ResolvedLocation.swift
@@ -1,0 +1,11 @@
+//
+//  ResolvedLocation.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 2/9/25.
+//
+
+struct ResolvedLocation: Equatable {
+    var depth: Int
+    var index: Int
+}

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -204,8 +204,10 @@ extension Resolver {
             return try handleBinary(leftExpr: leftExpr, operToken: operToken, rightExpr: rightExpr)
         case .unary(let operToken, let rightExpr):
             return try handleUnary(operToken: operToken, rightExpr: rightExpr)
-        case .literal(let valueToken, let value):
-            return .literal(valueToken, value)
+        case .boolLiteral(let valueToken, let value):
+            return .boolLiteral(valueToken, value)
+        case .doubleLiteral(let valueToken, let value):
+            return .doubleLiteral(valueToken, value)
         case .list(let leftBracketToken, let elements):
             return try handleList(leftBracketToken: leftBracketToken, elements: elements)
         case .tuple2(let leftParenToken, let expr0, let expr1):

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -19,15 +19,16 @@ struct Resolver {
         case methodCall
     }
 
-    private var scopeStack: [[ObjectName: Bool]]
+    private var scopeStack: [[ObjectName: (index: Int, isDefined: Bool)]]
+
     private var currentFunctionType: FunctionType = .none
     private var currentArgumentListType: ArgumentListType = .none
 
     init() {
-        var builtins = ScintillaBuiltin.allCases.map{ builtin in
-            (builtin.objectName, true)
+        var builtins = ScintillaBuiltin.allCases.enumerated().map{ (i, builtin) in
+            (builtin.objectName, (i, true))
         }
-        builtins.append((.variableName("PI"), true))
+        builtins.append((.variableName("PI"), (builtins.count, true)))
 
         self.scopeStack = [Dictionary(uniqueKeysWithValues: builtins)]
     }
@@ -78,7 +79,8 @@ extension Resolver {
             throw ResolverError.variableAlreadyDefined(objectName)
         }
 
-        scopeStack.lastMutable[objectName] = false
+        let index = scopeStack.last!.count
+        scopeStack.lastMutable[objectName] = (index, false)
     }
 
     mutating private func defineObject(objectName: ObjectName) {
@@ -90,14 +92,15 @@ extension Resolver {
             return
         }
 
-        scopeStack.lastMutable[objectName] = true
+        scopeStack.lastMutable[objectName]!.isDefined = true
     }
 
-    private func getDepth(name: ObjectName, nameToken: Token) throws -> Int {
+    private func getLocation(name: ObjectName, nameToken: Token) throws -> ResolvedLocation {
         var i = scopeStack.count - 1
         while i >= 0 {
-            if let _ = scopeStack[i][name] {
-                return scopeStack.count - 1 - i
+            if let (index, _) = scopeStack[i][name] {
+                let depth = scopeStack.count - 1 - i
+                return ResolvedLocation(depth: depth, index: index)
             }
 
             i = i - 1
@@ -127,7 +130,7 @@ extension Resolver {
 
 extension Resolver {
     // Main point of entry
-    mutating func resolve(program: Program<UnresolvedDepth>) throws -> Program<Int> {
+    mutating func resolve(program: Program<UnresolvedLocation>) throws -> Program<ResolvedLocation> {
         let resolvedStatements = try program.statements.map { statement in
             return try resolve(statement: statement)
         }
@@ -137,7 +140,7 @@ extension Resolver {
         return Program(statements: resolvedStatements, finalExpression: resolvedFinalExpression)
     }
 
-    private mutating func resolve(statement: Statement<UnresolvedDepth>) throws -> Statement<Int> {
+    private mutating func resolve(statement: Statement<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
         switch statement {
         case .letDeclaration(let nameToken, let initializeExpr):
             return try handleLetDeclaration(nameToken: nameToken, initializeExpr: initializeExpr)
@@ -152,7 +155,7 @@ extension Resolver {
     }
 
     mutating private func handleLetDeclaration(nameToken: Token,
-                                               initializeExpr: Expression<UnresolvedDepth>) throws -> Statement<Int> {
+                                               initializeExpr: Expression<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
         try declareVariable(variableToken: nameToken)
 
         let resolvedInitializerExpr = try resolve(expression: initializeExpr)
@@ -163,8 +166,8 @@ extension Resolver {
 
     mutating private func handleFunctionDeclaration(nameToken: Token,
                                                     argumentNames: [Token],
-                                                    letDecls: [Statement<UnresolvedDepth>],
-                                                    returnExpr: Expression<UnresolvedDepth>) throws -> Statement<Int> {
+                                                    letDecls: [Statement<UnresolvedLocation>],
+                                                    returnExpr: Expression<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
         try declareFunction(nameToken: nameToken, argumentNameTokens: argumentNames)
         defineFunction(nameToken: nameToken, argumentNameTokens: argumentNames)
 
@@ -187,13 +190,13 @@ extension Resolver {
         return .functionDeclaration(nameToken, argumentNames, resolvedLetDecls, resolvedReturnExpr)
     }
 
-    mutating private func handleExpressionStatement(expr: Expression<UnresolvedDepth>) throws -> Statement<Int> {
+    mutating private func handleExpressionStatement(expr: Expression<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
         let resolvedExpression = try resolve(expression: expr)
         return .expression(resolvedExpression)
     }
 
     // Resolver for expressions
-    mutating private func resolve(expression: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+    mutating private func resolve(expression: Expression<UnresolvedLocation>) throws -> Expression<ResolvedLocation> {
         switch expression {
         case .variable(let nameToken, _):
             return try handleVariable(nameToken: nameToken)
@@ -232,19 +235,20 @@ extension Resolver {
         }
     }
 
-    mutating private func handleVariable(nameToken: Token) throws -> Expression<Int> {
+    mutating private func handleVariable(nameToken: Token) throws -> Expression<ResolvedLocation> {
         let name: ObjectName = .variableName(nameToken.lexeme)
-        if !scopeStack.isEmpty && scopeStack.lastMutable[name] == false {
+        // TODO: Look into this later because this may be wrong
+        if !scopeStack.isEmpty && scopeStack.lastMutable[name]?.isDefined == false {
             throw ResolverError.variableAccessedBeforeInitialization(nameToken)
         }
 
-        let depth = try getDepth(name: name, nameToken: nameToken)
-        return .variable(nameToken, depth)
+        let location = try getLocation(name: name, nameToken: nameToken)
+        return .variable(nameToken, location)
     }
 
-    mutating private func handleBinary(leftExpr: Expression<UnresolvedDepth>,
+    mutating private func handleBinary(leftExpr: Expression<UnresolvedLocation>,
                                        operToken: Token,
-                                       rightExpr: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+                                       rightExpr: Expression<UnresolvedLocation>) throws -> Expression<ResolvedLocation> {
         let resolvedLeftExpr = try resolve(expression: leftExpr)
         let resolvedRightExpr = try resolve(expression: rightExpr)
 
@@ -252,14 +256,14 @@ extension Resolver {
     }
 
     mutating private func handleUnary(operToken: Token,
-                                      rightExpr: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+                                      rightExpr: Expression<UnresolvedLocation>) throws -> Expression<ResolvedLocation> {
         let resolvedRightExpr = try resolve(expression: rightExpr)
 
         return .unary(operToken, resolvedRightExpr)
     }
 
     mutating private func handleList(leftBracketToken: Token,
-                                     elements: [Expression<UnresolvedDepth>]) throws -> Expression<Int> {
+                                     elements: [Expression<UnresolvedLocation>]) throws -> Expression<ResolvedLocation> {
         let resolvedElements = try elements.map { element in
             return try resolve(expression: element)
         }
@@ -268,8 +272,8 @@ extension Resolver {
     }
 
     mutating private func handleTuple2(leftParenToken: Token,
-                                       expr0: Expression<UnresolvedDepth>,
-                                       expr1: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+                                       expr0: Expression<UnresolvedLocation>,
+                                       expr1: Expression<UnresolvedLocation>) throws -> Expression<ResolvedLocation> {
         let resolvedExpr0 = try resolve(expression: expr0)
         let resolvedExpr1 = try resolve(expression: expr1)
 
@@ -277,9 +281,9 @@ extension Resolver {
     }
 
     mutating private func handleTuple3(leftParenToken: Token,
-                                       expr0: Expression<UnresolvedDepth>,
-                                       expr1: Expression<UnresolvedDepth>,
-                                       expr2: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+                                       expr0: Expression<UnresolvedLocation>,
+                                       expr1: Expression<UnresolvedLocation>,
+                                       expr2: Expression<UnresolvedLocation>) throws -> Expression<ResolvedLocation> {
         let resolvedExpr0 = try resolve(expression: expr0)
         let resolvedExpr1 = try resolve(expression: expr1)
         let resolvedExpr2 = try resolve(expression: expr2)
@@ -288,7 +292,7 @@ extension Resolver {
     }
 
     mutating private func handleFunction(calleeToken: Token,
-                                         argumentNameTokens: [Token?]) throws -> Expression<Int> {
+                                         argumentNameTokens: [Token?]) throws -> Expression<ResolvedLocation> {
         let baseName = calleeToken.lexeme
         let argumentNames = argumentNameTokens.map { maybeNameToken in
             if let nameToken = maybeNameToken {
@@ -298,14 +302,14 @@ extension Resolver {
             return ""
         }
         let name: ObjectName = .functionName(baseName, argumentNames)
-        let depth = try getDepth(name: name, nameToken: calleeToken)
+        let location = try getLocation(name: name, nameToken: calleeToken)
 
-        return .function(calleeToken, argumentNameTokens, depth)
+        return .function(calleeToken, argumentNameTokens, location)
     }
 
-    mutating private func handleCall(calleeExpr: Expression<UnresolvedDepth>,
+    mutating private func handleCall(calleeExpr: Expression<UnresolvedLocation>,
                                      leftParenToken: Token,
-                                     arguments: [Expression<UnresolvedDepth>.Argument]) throws -> Expression<Int> {
+                                     arguments: [Expression<UnresolvedLocation>.Argument]) throws -> Expression<ResolvedLocation> {
         let previousArgumentListType = currentArgumentListType
         defer {
             currentArgumentListType = previousArgumentListType
@@ -315,7 +319,7 @@ extension Resolver {
         let argumentNames = arguments.map { $0.name }
         if case .variable(let baseNameToken, _) = calleeExpr {
             currentArgumentListType = .functionCall
-            newCalleeExpr = .function(baseNameToken, argumentNames, UnresolvedDepth())
+            newCalleeExpr = .function(baseNameToken, argumentNames, UnresolvedLocation())
         } else if case .method(let innerCalleeExpr, let baseNameToken, _) = calleeExpr {
             currentArgumentListType = .methodCall
             newCalleeExpr = .method(innerCalleeExpr, baseNameToken, argumentNames)
@@ -333,7 +337,7 @@ extension Resolver {
 
     mutating private func handleLambda(leftBraceToken: Token,
                                        argumentNames: [Token],
-                                       expression: Expression<UnresolvedDepth>) throws -> Expression<Int> {
+                                       expression: Expression<UnresolvedLocation>) throws -> Expression<ResolvedLocation> {
         beginScope()
         let previousFunctionType = currentFunctionType
         currentFunctionType = .lambda
@@ -352,9 +356,9 @@ extension Resolver {
         return .lambda(leftBraceToken, argumentNames, resolvedExpr)
     }
 
-    mutating private func handleMethod(calleeExpr: Expression<UnresolvedDepth>,
+    mutating private func handleMethod(calleeExpr: Expression<UnresolvedLocation>,
                                        methodName: Token,
-                                       argumentNameTokens: [Token?]) throws -> Expression<Int> {
+                                       argumentNameTokens: [Token?]) throws -> Expression<ResolvedLocation> {
         let resolvedCalleeExpr = try resolve(expression: calleeExpr)
 
         return .method(resolvedCalleeExpr, methodName, argumentNameTokens)

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -33,6 +33,9 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
     case parametricSurfaceLambdaWrongArity
     case missingLastExpression
     case lastExpressionNeedsToBeWorld
+    case couldNotEvaluateVariable(Token)
+    case couldNotEvaluateFunction(Token)
+    case couldNotConstructLambda(Token)
 
     var description: String {
         switch self {
@@ -84,6 +87,12 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[] Error: missing last expression"
         case .lastExpressionNeedsToBeWorld:
             return "[] Error: last expression needs to be world"
+        case .couldNotEvaluateVariable(let nameToken):
+            return "[\(nameToken.location)] Error: could not evaluate variable, \(nameToken.lexeme)"
+        case .couldNotEvaluateFunction(let nameToken):
+            return "[\(nameToken.location)] Error: could not evaluate function, \(nameToken.lexeme)"
+        case .couldNotConstructLambda(let exprToken):
+            return "[\(exprToken.location)] Error: could not evaluate function, \(exprToken.lexeme)"
         }
     }
 }

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -28,6 +28,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
     case expectedCamera
     case expectedLight
     case expectedShape
+    case expectedUserDefinedFunction
+    case implicitSurfaceLambdaWrongArity
     case missingLastExpression
     case lastExpressionNeedsToBeWorld
 
@@ -71,6 +73,10 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[] Error: expected the argument to be a list of Shapes"
         case .incorrectObject:
             return "[] Error: method does not exist on object"
+        case .expectedUserDefinedFunction:
+            return "[] Error: expected user-defined function"
+        case .implicitSurfaceLambdaWrongArity:
+            return "[] Error: implicit surface lambda must take three arguments"
         case .missingLastExpression:
             return "[] Error: missing last expression"
         case .lastExpressionNeedsToBeWorld:

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 enum RuntimeError: LocalizedError, CustomStringConvertible {
-    case undefinedVariable(Location, Substring)
-    case undefinedFunction(Location, Substring)
-    case undefinedMethod(Location, Substring)
-    case unsupportedUnaryOperator(Location, Substring)
-    case unaryOperandMustBeNumber(Location, Substring)
-    case unsupportedBinaryOperator(Location, Substring)
-    case binaryOperandsMustBeNumbers(Location, Substring)
-    case notAFunction(Location, Substring)
-    case notCallable(Location, Substring)
+    case undefinedVariable(SourceLocation, Substring)
+    case undefinedFunction(SourceLocation, Substring)
+    case undefinedMethod(SourceLocation, Substring)
+    case unsupportedUnaryOperator(SourceLocation, Substring)
+    case unaryOperandMustBeNumber(SourceLocation, Substring)
+    case unsupportedBinaryOperator(SourceLocation, Substring)
+    case binaryOperandsMustBeNumbers(SourceLocation, Substring)
+    case notAFunction(SourceLocation, Substring)
+    case notCallable(SourceLocation, Substring)
     // TODO: Need to capture location and lexemes for the following three error cases
     case missingArgumentName(Token)
     case incorrectArgument

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -30,6 +30,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
     case expectedShape
     case expectedUserDefinedFunction
     case implicitSurfaceLambdaWrongArity
+    case parametricSurfaceLambdaWrongArity
     case missingLastExpression
     case lastExpressionNeedsToBeWorld
 
@@ -77,6 +78,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible {
             return "[] Error: expected user-defined function"
         case .implicitSurfaceLambdaWrongArity:
             return "[] Error: implicit surface lambda must take three arguments"
+        case .parametricSurfaceLambdaWrongArity:
+            return "[] Error: parametric surface lambda must take two arguments"
         case .missingLastExpression:
             return "[] Error: missing last expression"
         case .lastExpressionNeedsToBeWorld:

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -37,6 +37,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case intersection
     case union
     case sinFunc
+    case cosFunc
+    case tanFunc
 
     var objectName: ObjectName {
         switch self {
@@ -94,6 +96,10 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .methodName(.shape, "union", ["shapes"])
         case .sinFunc:
             return .functionName("sin", [""])
+        case .cosFunc:
+            return .functionName("cos", [""])
+        case .tanFunc:
+            return .functionName("tan", [""])
         }
     }
 
@@ -131,7 +137,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         case .world:
             return try makeWorld(argumentValues: argumentValues)
         case .sinFunc:
-            return try handleSinFunc(argumentValues: argumentValues)
+            return try handleTrigFunction(argumentValues: argumentValues,
+                                          nativeTrigFunction: sin)
+        case .cosFunc:
+            return try handleTrigFunction(argumentValues: argumentValues,
+                                          nativeTrigFunction: cos)
+        case .tanFunc:
+            return try handleTrigFunction(argumentValues: argumentValues,
+                                          nativeTrigFunction: tan)
         default:
             fatalError("Internal error: method calls should not get here")
         }
@@ -395,10 +408,11 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         }
     }
 
-    private func handleSinFunc(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+    private func handleTrigFunction(argumentValues: [ScintillaValue],
+                                    nativeTrigFunction: (Double) -> Double) throws -> ScintillaValue {
         let rawArgumentValue = try extractRawDouble(argumentValue: argumentValues[0])
 
-        return .double(sin(rawArgumentValue))
+        return .double(nativeTrigFunction(rawArgumentValue))
     }
 
     private func extractRawBoolean(argumentValue: ScintillaValue) throws -> Bool {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -16,7 +16,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case group
     case implicitSurface1
     case implicitSurface2
-    case parametricSurface
+    case parametricSurface1
+    case parametricSurface2
     case plane
     case prism
     case sphere
@@ -55,9 +56,15 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("ImplicitSurface", ["bottomFrontLeft", "topBackRight", "function"])
         case .implicitSurface2:
             return .functionName("ImplicitSurface", ["center", "radius", "function"])
-        case .parametricSurface:
+        // TODO: Add second constructor exposing accuracy and maxGradient parameters
+        case .parametricSurface1:
             return .functionName("ParametricSurface", ["bottomFrontLeft", "topBackRight",
                                                        "uRange", "vRange",
+                                                       "fx", "fy", "fz"])
+        case .parametricSurface2:
+            return .functionName("ParametricSurface", ["bottomFrontLeft", "topBackRight",
+                                                       "uRange", "vRange",
+                                                       "accuracy", "maxGradient",
                                                        "fx", "fy", "fz"])
         case .plane:
             return .functionName("Plane", [])
@@ -123,8 +130,10 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return try makeImplicitSurface1(evaluator: evaluator, argumentValues: argumentValues)
         case .implicitSurface2:
             return try makeImplicitSurface2(evaluator: evaluator, argumentValues: argumentValues)
-        case .parametricSurface:
-            return try makeParametricSurface(evaluator: evaluator, argumentValues: argumentValues)
+        case .parametricSurface1:
+            return try makeParametricSurface1(evaluator: evaluator, argumentValues: argumentValues)
+        case .parametricSurface2:
+            return try makeParametricSurface2(evaluator: evaluator, argumentValues: argumentValues)
         case .plane:
             return .shape(Plane())
         case .prism:
@@ -243,7 +252,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         return .shape(implicitSurface)
     }
 
-    private func makeParametricSurface(evaluator: Evaluator,
+    private func makeParametricSurface1(evaluator: Evaluator,
                                         argumentValues: [ScintillaValue]) throws -> ScintillaValue {
         let bottomFrontLeft = try extractRawTuple3(argumentValue: argumentValues[0])
         let topBackRight = try extractRawTuple3(argumentValue: argumentValues[1])
@@ -260,6 +269,31 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
                                                 topBackRight: topBackRight,
                                                 uRange: uRange,
                                                 vRange: vRange,
+                                                fx: fx, fy: fy, fz: fz)
+        return .shape(parametricSurface)
+    }
+
+    private func makeParametricSurface2(evaluator: Evaluator,
+                                        argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let bottomFrontLeft = try extractRawTuple3(argumentValue: argumentValues[0])
+        let topBackRight = try extractRawTuple3(argumentValue: argumentValues[1])
+        let uRange = try extractRawTuple2(argumentValue: argumentValues[2])
+        let vRange = try extractRawTuple2(argumentValue: argumentValues[3])
+        let accuracy = try extractRawDouble(argumentValue: argumentValues[4])
+        let maxGradient = try extractRawDouble(argumentValue: argumentValues[5])
+        let fx = try extractRawParametricSurfaceFunction(evaluator: evaluator,
+                                                         argumentValue: argumentValues[6])
+        let fy = try extractRawParametricSurfaceFunction(evaluator: evaluator,
+                                                         argumentValue: argumentValues[7])
+        let fz = try extractRawParametricSurfaceFunction(evaluator: evaluator,
+                                                         argumentValue: argumentValues[8])
+
+        let parametricSurface = ParametricSurface(bottomFrontLeft: bottomFrontLeft,
+                                                topBackRight: topBackRight,
+                                                uRange: uRange,
+                                                vRange: vRange,
+                                                accuracy: accuracy,
+                                                maxGradient: maxGradient,
                                                 fx: fx, fy: fy, fz: fz)
         return .shape(parametricSurface)
     }

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -56,7 +56,6 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("ImplicitSurface", ["bottomFrontLeft", "topBackRight", "function"])
         case .implicitSurface2:
             return .functionName("ImplicitSurface", ["center", "radius", "function"])
-        // TODO: Add second constructor exposing accuracy and maxGradient parameters
         case .parametricSurface1:
             return .functionName("ParametricSurface", ["bottomFrontLeft", "topBackRight",
                                                        "uRange", "vRange",
@@ -266,10 +265,10 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
                                                          argumentValue: argumentValues[6])
 
         let parametricSurface = ParametricSurface(bottomFrontLeft: bottomFrontLeft,
-                                                topBackRight: topBackRight,
-                                                uRange: uRange,
-                                                vRange: vRange,
-                                                fx: fx, fy: fy, fz: fz)
+                                                  topBackRight: topBackRight,
+                                                  uRange: uRange,
+                                                  vRange: vRange,
+                                                  fx: fx, fy: fy, fz: fz)
         return .shape(parametricSurface)
     }
 
@@ -289,12 +288,12 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
                                                          argumentValue: argumentValues[8])
 
         let parametricSurface = ParametricSurface(bottomFrontLeft: bottomFrontLeft,
-                                                topBackRight: topBackRight,
-                                                uRange: uRange,
-                                                vRange: vRange,
-                                                accuracy: accuracy,
-                                                maxGradient: maxGradient,
-                                                fx: fx, fy: fy, fz: fz)
+                                                  topBackRight: topBackRight,
+                                                  uRange: uRange,
+                                                  vRange: vRange,
+                                                  accuracy: accuracy,
+                                                  maxGradient: maxGradient,
+                                                  fx: fx, fy: fy, fz: fz)
         return .shape(parametricSurface)
     }
 
@@ -529,56 +528,6 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         return (rawDouble0, rawDouble1, rawDouble2)
     }
 
-    private func extractRawImplicitSurfaceFunction(evaluator: Evaluator,
-                                                   argumentValue: ScintillaValue) throws -> ImplicitSurfaceLambda {
-        guard case .implicitSurfaceLambda(let udf) = argumentValue else {
-            throw RuntimeError.expectedUserDefinedFunction
-        }
-
-        guard udf.argumentNames.count == 3 else {
-            throw RuntimeError.implicitSurfaceLambdaWrongArity
-        }
-
-        let lambda = { (x: Double, y: Double, z: Double) -> Double in
-            // TODO: Figure out how to surface either of these errors _without_ throwing
-            let result: Double
-            do {
-                result = try udf.call(evaluator: evaluator, argumentValues: x, y, z)
-            } catch {
-                fatalError("Something bad happened during the execution of the implicit surface lambda")
-            }
-
-            return result
-        }
-
-        return lambda
-    }
-
-    private func extractRawParametricSurfaceFunction(evaluator: Evaluator,
-                                                     argumentValue: ScintillaValue) throws -> ParametricSurfaceLambda {
-        guard case .implicitSurfaceLambda(let udf) = argumentValue else {
-            throw RuntimeError.expectedUserDefinedFunction
-        }
-
-        guard udf.argumentNames.count == 2 else {
-            throw RuntimeError.parametricSurfaceLambdaWrongArity
-        }
-
-        let lambda = { (u: Double, v: Double) -> Double in
-            // TODO: Figure out how to surface either of these errors _without_ throwing
-            let result: Double
-            do {
-                result = try udf.call(evaluator: evaluator, argumentValues: u, v, 0.0)
-            } catch {
-                fatalError("Something bad happened during the execution of the implicit surface lambda")
-            }
-
-            return result
-        }
-
-        return lambda
-    }
-
     private func extractRawCamera(argumentValue: ScintillaValue) throws -> Camera {
         guard case .camera(let rawCamera) = argumentValue else {
             throw RuntimeError.expectedCamera
@@ -621,5 +570,126 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         }
 
         return shape
+    }
+
+    private func extractRawImplicitSurfaceFunction(evaluator: Evaluator,
+                                                   argumentValue: ScintillaValue) throws -> ImplicitSurfaceLambda {
+        guard case .lambda(let udf) = argumentValue else {
+            throw RuntimeError.expectedUserDefinedFunction
+        }
+
+        guard udf.argumentNames.count == 3 else {
+            throw RuntimeError.implicitSurfaceLambdaWrongArity
+        }
+
+        return try makeRawLambda(evaluator: evaluator,
+                                 expression: udf.returnExpr)
+    }
+
+    private func extractRawParametricSurfaceFunction(evaluator: Evaluator,
+                                                     argumentValue: ScintillaValue) throws -> ParametricSurfaceLambda {
+        guard case .lambda(let udf) = argumentValue else {
+            throw RuntimeError.expectedUserDefinedFunction
+        }
+
+        guard udf.argumentNames.count == 2 else {
+            throw RuntimeError.parametricSurfaceLambdaWrongArity
+        }
+
+        let innerLambda = try makeRawLambda(evaluator: evaluator, expression: udf.returnExpr)
+        return { x, y in innerLambda(x, y, 0) }
+    }
+
+    private func makeRawLambda(evaluator: Evaluator,
+                               expression: Expression<ResolvedLocation>) throws -> ImplicitSurfaceLambda {
+        switch expression {
+        case .doubleLiteral(_, let rawDouble):
+            return { _, _, _ in rawDouble }
+        case .variable(let nameToken, let location):
+            switch (location.depth, location.index) {
+            case (0, 0):
+                return { x, _, _ in return x }
+            case (0, 1):
+                return { _, y, _ in return y }
+            case (0, 2):
+                return { _, _, z in return z }
+            default:
+                var copy = location
+                copy.depth -= 1
+                let foo = try evaluator.environment.getValueAtLocation(location: copy)
+                if case .double(let value) = foo {
+                    return { _, _, _ in return value }
+                }
+            }
+
+            throw RuntimeError.couldNotEvaluateVariable(nameToken)
+        case .binary(let leftExpr, let operToken, let rightExpr):
+            let leftValue = try makeRawLambda(evaluator: evaluator, expression: leftExpr)
+            let rightValue = try makeRawLambda(evaluator: evaluator, expression: rightExpr)
+
+            switch operToken.type {
+            case .plus:
+                return { x, y, z in leftValue(x, y, z) + rightValue(x, y, z) }
+            case .minus:
+                return { x, y, z in leftValue(x, y, z) - rightValue(x, y, z) }
+            case .star:
+                return { x, y, z in leftValue(x, y, z) * rightValue(x, y, z) }
+            case .slash:
+                return { x, y, z in leftValue(x, y, z) / rightValue(x, y, z) }
+            default:
+                throw RuntimeError.unsupportedBinaryOperator(operToken.location, operToken.lexeme)
+            }
+        case .call(let calleeExpr, _, let localArguments):
+            guard case .function(_, _, let location) = calleeExpr else {
+                throw RuntimeError.notAFunction(calleeExpr.locationToken.location, calleeExpr.locationToken.lexeme)
+            }
+
+            let firstArgValue = try makeRawLambda(evaluator: evaluator,
+                                                  expression: localArguments[0].value)
+
+            var copy = location
+            copy.depth -= 1
+            let lookedUpFunction = try evaluator.environment.getValueAtLocation(location: copy)
+
+            switch lookedUpFunction {
+            case .builtin(.sinFunc):
+                return { x, y, z in return sin(firstArgValue(x, y, z)) }
+            case .builtin(.cosFunc):
+                return { x, y, z in return cos(firstArgValue(x, y, z)) }
+            case .builtin(.tanFunc):
+                return { x, y, z in return tan(firstArgValue(x, y, z)) }
+            case .userDefinedFunction(let udf):
+                var secondArgValue: ImplicitSurfaceLambda = { _, _, _ in 0.0 }
+                var thirdArgValue: ImplicitSurfaceLambda = { _, _, _ in 0.0 }
+                if localArguments.count == 3 {
+                    thirdArgValue = try makeRawLambda(evaluator: evaluator,
+                                                      expression: localArguments[2].value)
+                }
+
+                if localArguments.count >= 2 {
+                    secondArgValue = try makeRawLambda(evaluator: evaluator,
+                                                       expression: localArguments[1].value)
+                }
+
+                return { (x: Double, y: Double, z: Double) -> Double in
+                    // TODO: Figure out how to surface either of these errors _without_ throwing
+                    let result: Double
+                    do {
+                        result = try udf.call(evaluator: evaluator,
+                                              argumentValues: firstArgValue(x, y, z),
+                                              secondArgValue(x, y, z),
+                                              thirdArgValue(x, y, z))
+                    } catch {
+                        fatalError("Something bad happened during the execution of the lambda")
+                    }
+
+                    return result
+                }
+            default:
+                throw RuntimeError.couldNotEvaluateFunction(calleeExpr.locationToken)
+            }
+        default:
+            throw RuntimeError.couldNotConstructLambda(expression.locationToken)
+        }
     }
 }

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -256,12 +256,12 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         let fz = try extractRawParametricSurfaceFunction(evaluator: evaluator,
                                                          argumentValue: argumentValues[6])
 
-        let implicitSurface = ParametricSurface(bottomFrontLeft: bottomFrontLeft,
+        let parametricSurface = ParametricSurface(bottomFrontLeft: bottomFrontLeft,
                                                 topBackRight: topBackRight,
                                                 uRange: uRange,
                                                 vRange: vRange,
                                                 fx: fx, fy: fy, fz: fz)
-        return .shape(implicitSurface)
+        return .shape(parametricSurface)
     }
 
     private func makePrism(argumentValues: [ScintillaValue]) throws -> ScintillaValue {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -506,23 +506,15 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         }
 
         let lambda = { (x: Double, y: Double, z: Double) -> Double in
-            let argumentValues: [ScintillaValue] = [
-                .double(x), .double(y), .double(z)
-            ]
-
             // TODO: Figure out how to surface either of these errors _without_ throwing
-            let result: ScintillaValue
+            let result: Double
             do {
-                result = try udf.call(evaluator: evaluator, argumentValues: argumentValues)
+                result = try udf.call(evaluator: evaluator, argumentValues: x, y, z)
             } catch {
                 fatalError("Something bad happened during the execution of the implicit surface lambda")
             }
 
-            guard case .double(let numericResult) = result else {
-                fatalError("Return value of implicit surface lambda was not a double")
-            }
-
-            return numericResult
+            return result
         }
 
         return lambda
@@ -539,21 +531,15 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         }
 
         let lambda = { (u: Double, v: Double) -> Double in
-            let argumentValues: [ScintillaValue] = [.double(u), .double(v)]
-
             // TODO: Figure out how to surface either of these errors _without_ throwing
-            let result: ScintillaValue
+            let result: Double
             do {
-                result = try udf.call(evaluator: evaluator, argumentValues: argumentValues)
+                result = try udf.call(evaluator: evaluator, argumentValues: u, v, 0.0)
             } catch {
                 fatalError("Something bad happened during the execution of the implicit surface lambda")
             }
 
-            guard case .double(let numericResult) = result else {
-                fatalError("Return value of implicit surface lambda was not a double")
-            }
-
-            return numericResult
+            return result
         }
 
         return lambda

--- a/ScintillaApp/ScintillaType.swift
+++ b/ScintillaApp/ScintillaType.swift
@@ -13,7 +13,7 @@ enum ScintillaType {
     case tuple3
     case builtin
     case boundMethod
-    case lambda
+    case implicitSurfaceLambda
     case userDefinedFunction
     case shape
     case camera

--- a/ScintillaApp/ScintillaType.swift
+++ b/ScintillaApp/ScintillaType.swift
@@ -13,7 +13,7 @@ enum ScintillaType {
     case tuple3
     case builtin
     case boundMethod
-    case implicitSurfaceLambda
+    case lambda
     case userDefinedFunction
     case shape
     case camera

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -12,14 +12,14 @@ import Foundation
 typealias ImplicitSurfaceLambda = (Double, Double, Double) -> Double
 typealias ParametricSurfaceLambda = (Double, Double) -> Double
 
-enum ScintillaValue: Equatable, CustomStringConvertible {
+indirect enum ScintillaValue: Equatable, CustomStringConvertible {
     case boolean(Bool)
     case double(Double)
     case list([ScintillaValue])
-    indirect case tuple2((ScintillaValue, ScintillaValue))
-    indirect case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
+    case tuple2((ScintillaValue, ScintillaValue))
+    case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
     case builtin(ScintillaBuiltin)
-    indirect case boundMethod(ScintillaValue, ScintillaBuiltin)
+    case boundMethod(ScintillaValue, ScintillaBuiltin)
     case implicitSurfaceLambda(UserDefinedFunction)
     case userDefinedFunction(UserDefinedFunction)
     case shape(any Shape)

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -12,20 +12,20 @@ import Foundation
 typealias ImplicitSurfaceLambda = (Double, Double, Double) -> Double
 typealias ParametricSurfaceLambda = (Double, Double) -> Double
 
-indirect enum ScintillaValue: Equatable, CustomStringConvertible {
+enum ScintillaValue: Equatable, CustomStringConvertible {
     case boolean(Bool)
     case double(Double)
-    case list([ScintillaValue])
-    case tuple2((ScintillaValue, ScintillaValue))
-    case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
+    indirect case list([ScintillaValue])
+    indirect case tuple2((ScintillaValue, ScintillaValue))
+    indirect case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
     case builtin(ScintillaBuiltin)
-    case boundMethod(ScintillaValue, ScintillaBuiltin)
-    case implicitSurfaceLambda(UserDefinedFunction)
-    case userDefinedFunction(UserDefinedFunction)
-    case shape(any Shape)
-    case camera(Camera)
-    case light(Light)
-    case world(World)
+    indirect case boundMethod(ScintillaValue, ScintillaBuiltin)
+    indirect case implicitSurfaceLambda(UserDefinedFunction)
+    indirect case userDefinedFunction(UserDefinedFunction)
+    indirect case shape(any Shape)
+    indirect case camera(Camera)
+    indirect case light(Light)
+    indirect case world(World)
 
     var type: ScintillaType {
         switch self {

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -9,8 +9,8 @@ import ScintillaLib
 
 import Foundation
 
-// TODO: Will likely need to revisit this when we introduce ParametricSurface
 typealias ImplicitSurfaceLambda = (Double, Double, Double) -> Double
+typealias ParametricSurfaceLambda = (Double, Double) -> Double
 
 enum ScintillaValue: Equatable, CustomStringConvertible {
     case boolean(Bool)

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -10,7 +10,7 @@ import ScintillaLib
 import Foundation
 
 // TODO: Will likely need to revisit this when we introduce ParametricSurface
-typealias Lambda = (Double, Double, Double) -> Double
+typealias ImplicitSurfaceLambda = (Double, Double, Double) -> Double
 
 enum ScintillaValue: Equatable, CustomStringConvertible {
     case boolean(Bool)
@@ -20,7 +20,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
     indirect case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
     case builtin(ScintillaBuiltin)
     indirect case boundMethod(ScintillaValue, ScintillaBuiltin)
-    case lambda(Lambda, UUID)
+    case implicitSurfaceLambda(UserDefinedFunction)
     case userDefinedFunction(UserDefinedFunction)
     case shape(any Shape)
     case camera(Camera)
@@ -43,8 +43,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return .builtin
         case .boundMethod:
             return .boundMethod
-        case .lambda:
-            return .lambda
+        case .implicitSurfaceLambda:
+            return .implicitSurfaceLambda
         case .userDefinedFunction:
             return .userDefinedFunction
         case .shape(_):
@@ -74,8 +74,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return l == r
         case (.boundMethod(let l1, let l2), .boundMethod(let r1, let r2)):
             return l1 == r1 && l2 == r2
-        case (.lambda(_, let leftId), .lambda(_, let rightId)):
-            return leftId == rightId
+        case (.implicitSurfaceLambda(let l), .implicitSurfaceLambda(let r)):
+            return l.objectId == r.objectId
         case (.userDefinedFunction(let l), .userDefinedFunction(let r)):
             return l.objectId == r.objectId
         case (.shape(let l), .shape(let r)):
@@ -114,8 +114,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return "\(builtin.objectName)"
         case .boundMethod(_, let builtin):
             return "\(builtin.objectName)"
-        case .lambda(let lambda, _):
-            return "<lambda>"
+        case .implicitSurfaceLambda(let userDefinedFunction):
+            return "<implicit surface lambda: \(userDefinedFunction.objectId)>"
         case .userDefinedFunction(let userDefinedFunction):
             return "<function: \(userDefinedFunction.name)>"
         case .shape(let shape):
@@ -131,7 +131,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
 
     var isCallable: Bool {
         switch self {
-        case .builtin, .boundMethod, .lambda, .userDefinedFunction:
+        case .builtin, .boundMethod, .implicitSurfaceLambda, .userDefinedFunction:
             return true
         default:
             return false

--- a/ScintillaApp/ScintillaValue.swift
+++ b/ScintillaApp/ScintillaValue.swift
@@ -20,7 +20,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
     indirect case tuple3((ScintillaValue, ScintillaValue, ScintillaValue))
     case builtin(ScintillaBuiltin)
     indirect case boundMethod(ScintillaValue, ScintillaBuiltin)
-    indirect case implicitSurfaceLambda(UserDefinedFunction)
+    indirect case lambda(UserDefinedFunction)
     indirect case userDefinedFunction(UserDefinedFunction)
     indirect case shape(any Shape)
     indirect case camera(Camera)
@@ -43,8 +43,8 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return .builtin
         case .boundMethod:
             return .boundMethod
-        case .implicitSurfaceLambda:
-            return .implicitSurfaceLambda
+        case .lambda:
+            return .lambda
         case .userDefinedFunction:
             return .userDefinedFunction
         case .shape(_):
@@ -74,7 +74,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return l == r
         case (.boundMethod(let l1, let l2), .boundMethod(let r1, let r2)):
             return l1 == r1 && l2 == r2
-        case (.implicitSurfaceLambda(let l), .implicitSurfaceLambda(let r)):
+        case (.lambda(let l), .lambda(let r)):
             return l.objectId == r.objectId
         case (.userDefinedFunction(let l), .userDefinedFunction(let r)):
             return l.objectId == r.objectId
@@ -114,7 +114,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
             return "\(builtin.objectName)"
         case .boundMethod(_, let builtin):
             return "\(builtin.objectName)"
-        case .implicitSurfaceLambda(let userDefinedFunction):
+        case .lambda(let userDefinedFunction):
             return "<implicit surface lambda: \(userDefinedFunction.objectId)>"
         case .userDefinedFunction(let userDefinedFunction):
             return "<function: \(userDefinedFunction.name)>"
@@ -131,7 +131,7 @@ enum ScintillaValue: Equatable, CustomStringConvertible {
 
     var isCallable: Bool {
         switch self {
-        case .builtin, .boundMethod, .implicitSurfaceLambda, .userDefinedFunction:
+        case .builtin, .boundMethod, .lambda, .userDefinedFunction:
             return true
         default:
             return false

--- a/ScintillaApp/SourceLocation.swift
+++ b/ScintillaApp/SourceLocation.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 1/22/25.
 //
 
-public struct Location: CustomStringConvertible {
+public struct SourceLocation: CustomStringConvertible {
     public let line: Int
     public let column: Int
 

--- a/ScintillaApp/Statement.swift
+++ b/ScintillaApp/Statement.swift
@@ -5,10 +5,10 @@
 //  Created by Danielle Kefford on 1/23/25.
 //
 
-enum Statement<Depth: Equatable>: Equatable {
-    case letDeclaration(Token, Expression<Depth>)
-    case functionDeclaration(Token, [Token], [Statement<Depth>], Expression<Depth>)
-    case expression(Expression<Depth>)
+enum Statement<Location: Equatable>: Equatable {
+    case letDeclaration(Token, Expression<Location>)
+    case functionDeclaration(Token, [Token], [Statement<Location>], Expression<Location>)
+    case expression(Expression<Location>)
 
     var locationToken: Token {
         switch self {

--- a/ScintillaApp/Substring+location.swift
+++ b/ScintillaApp/Substring+location.swift
@@ -6,7 +6,7 @@
 //
 
 extension Substring {
-    public func location() -> Location {
+    public func location() -> SourceLocation {
         var line: Int = 1
         var column: Int = 1
 
@@ -19,6 +19,6 @@ extension Substring {
             }
         }
 
-        return Location(line: line, column: column)
+        return SourceLocation(line: line, column: column)
     }
 }

--- a/ScintillaApp/Token.swift
+++ b/ScintillaApp/Token.swift
@@ -18,7 +18,7 @@ struct Token: CustomStringConvertible, Equatable, Hashable {
         return "Location: \(self.location), type: \(self.type), lexeme: \(self.lexeme)"
     }
 
-    var location: Location {
+    var location: SourceLocation {
         self.lexeme.location()
     }
 }

--- a/ScintillaApp/UnresolvedLocation.swift
+++ b/ScintillaApp/UnresolvedLocation.swift
@@ -7,5 +7,5 @@
 
 // NOTA BENE: This struct is used in the parsing stage so that we
 // can later use that same AST in the resolver with _actual_ depths
-struct UnresolvedDepth: Equatable {
+struct UnresolvedLocation: Equatable {
 }

--- a/ScintillaApp/UserDefinedFunction.swift
+++ b/ScintillaApp/UserDefinedFunction.swift
@@ -15,9 +15,14 @@ struct UserDefinedFunction: Equatable {
     var returnExpr: Expression<ResolvedLocation>
     var objectId: UUID = UUID()
 
+    var expectedCapacity: Int {
+        return letDecls.count + argumentNames.count
+    }
+
     // General case
     func call(evaluator: Evaluator, argumentValues: [ScintillaValue]) throws -> ScintillaValue {
         let newEnvironment = evaluator.recycleEnvironment(enclosingEnvironment: self.enclosingEnvironment)
+        newEnvironment.reserveCapacity(capacity: self.expectedCapacity)
 
         for (i, argumentName) in argumentNames.enumerated() {
             let argumentValue = argumentValues[i]
@@ -41,6 +46,7 @@ struct UserDefinedFunction: Equatable {
     // Specific case for a function that oniy takes Doubles and returns a Double
     func call(evaluator: Evaluator, argumentValues a1: Double, _ a2: Double, _ a3: Double) throws -> Double {
         let newEnvironment = evaluator.recycleEnvironment(enclosingEnvironment: self.enclosingEnvironment)
+        newEnvironment.reserveCapacity(capacity: self.expectedCapacity)
 
         func setArgument(_ index: Int, _ value: Double) {
             guard index < argumentNames.count else { return }

--- a/ScintillaApp/UserDefinedFunction.swift
+++ b/ScintillaApp/UserDefinedFunction.swift
@@ -11,12 +11,12 @@ struct UserDefinedFunction: Equatable {
     var name: String
     var argumentNames: [Token]
     var enclosingEnvironment: Environment
-    var letDecls: [Statement<Int>]
-    var returnExpr: Expression<Int>
+    var letDecls: [Statement<ResolvedLocation>]
+    var returnExpr: Expression<ResolvedLocation>
     var objectId: UUID = UUID()
 
     func call(evaluator: Evaluator, argumentValues: [ScintillaValue]) throws -> ScintillaValue {
-        let newEnvironment = Environment(enclosingEnvironment: enclosingEnvironment)
+        let newEnvironment = evaluator.recycleEnvironment(enclosingEnvironment: self.enclosingEnvironment)
 
         for (i, argumentName) in argumentNames.enumerated() {
             let argumentValue = argumentValues[i]


### PR DESCRIPTION
The primary objective of this PR is to introduce support for so-called parametric surfaces, which are ones that are defined by _three_ equations in two variables for the x, y, and z coordinates. Two new constructors were exposed for the `ParametricSurface` object in the native Scintilla library, with the following parameter sets:

* one specifying the bounding box, the equations for the three coordinates, and the ranges of the dependent variables `u` and `v` referenced in those equations
* the other including those above and two additional parameters, `accuracy` and `maxGradient`, both of which control the quality of the resultant image

Since it turns out that the equations for many parametric surfaces use `sin()` and `cos()`, this PR includes new builtins for the three basic trigonometric functions.

However the bulk of the work here was to improve the performance of the new shape type, as well as for `ImplicitSurface`; those changes included the following:

* Introduction of `Evaluator.recycleEnvironment()`: After some profiling, it turned out that one of the more expensive operations in the initial implementation was the constant creation of new instances of `Environment`. This new method now curtails that behavior by reusing instances as much as possible.
* Splitting up of single lookup table into array of `ScintillaValue`s and dictionary of object names to locations: More profiling revealing that a lot of time was being spent hashing `ObjectName` values when resolving variables and function names. And so now the lookup table is split into two structures, the array for resolving variables directly by index, and the dictionary first when resolving functions by name. Doing that required some other changes, namely
 
* The type associated with resolved expressions and statements is no longer a single `Int` but instead a `ResolvedLocaton` struct with _two_ properties, index and depth
* `Resolver.scopeStack` now tracks both index and isDefined boolean

Once the above low-level enhancements were completed, the performance of rendering parametric surfaces was still abhorrently slow; namely that during rendering the resultant calling of `UserDefinedFunction`s resulted in the evaluation of their bodies _for every single pixel in the image_. After some experimentation, it turned out that evaluating the `UserDefinedFunction` _once_ per coordinate and producing a lambda that was composed of a tree of closures _only involving the handling of raw `Double` values_ resulted in _significantly_ faster rendering times. Doing that required a series of other changes:

* `Expressions.literal()` is now split into `.doubleLiteral()` and `booleanLiteral()` cases. 
* Lambda bodies are now temporarily housed in `UserDefinedFunction` until evaluated.
* The logic for constructing lambdas for implicit and parametric surfaces is now in one function that is called by both handlers.
* In the event that a function cannot be reduced to one taking and returning only `Double` values, the original `UserDefinedFunction.call()` will handle the general case and use the `Evaluator`

It should be noted that there was also a bug in the parser which improperly handled parameter labels; as part of the fix for that we introduced of `Parser.nextToken()` to be able to look ahead without consuming the next token.