### PR TITLE
Added some more unary functions and an exponentiation operator

### DIFF
--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -188,6 +188,8 @@ class Evaluator {
             return leftNumber * rightNumber
         case .slash:
             return leftNumber / rightNumber
+        case .caret:
+            return pow(leftNumber, rightNumber)
         default:
             throw RuntimeError.unsupportedBinaryOperator(oper.location, oper.lexeme)
         }

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -192,9 +192,21 @@ extension Parser {
     }
 
     mutating private func parseFactor() throws -> Expression<UnresolvedLocation> {
+        var expr = try parseExponent()
+
+        while currentTokenMatchesAny(types: [.slash, .star]) {
+            let oper = previousToken
+            let rightExpr = try parseExponent()
+            expr = .binary(expr, oper, rightExpr)
+        }
+
+        return expr
+    }
+
+    mutating private func parseExponent() throws -> Expression<UnresolvedLocation> {
         var expr = try parseUnary()
 
-        while currentTokenMatchesAny(types: [.slash, .star, .modulus]) {
+        while currentTokenMatchesAny(types: [.caret]) {
             let oper = previousToken
             let rightExpr = try parseUnary()
             expr = .binary(expr, oper, rightExpr)
@@ -204,7 +216,7 @@ extension Parser {
     }
 
     mutating private func parseUnary() throws -> Expression<UnresolvedLocation> {
-        // NOTA BENE: For the time being, the onky unary expression allowed is
+        // NOTA BENE: For the time being, the only unary expression allowed is
         // one that involves a single minus sign.
         if currentTokenMatchesAny(types: [.minus]) {
             let oper = previousToken

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -84,7 +84,8 @@ extension Parser {
     //    argList        → IDENTIFIER ("," IDENTIFIER)*
     //    expression     → term ;
     //    term           → factor ( ( "-" | "+" ) factor )* ;
-    //    factor         → unary ( ( "/" | "*" | "%" ) unary )* ;
+    //    factor         → exponent ( ( "/" | "*" ) exponent )* ;
+    //    exponent       → unary ( ( "^" unary )* ;
     //    unary          → ( "!" | "-" | "*" ) unary
     //                   | postfix ;
     //    postfix        → primary | method | call ;

--- a/ScintillaApp/TokenType.swift
+++ b/ScintillaApp/TokenType.swift
@@ -22,7 +22,7 @@ enum TokenType: Equatable {
     case minus
     case star
     case slash
-    case modulus
+    case caret
 
     // Literals
     case identifier

--- a/ScintillaApp/Tokenizer.swift
+++ b/ScintillaApp/Tokenizer.swift
@@ -117,7 +117,7 @@ struct Tokenizer {
             "+": .plus,
             "-": .minus,
             "*": .star,
-            "%": .modulus,
+            "^": .caret,
         ]) {
             return handleSingleCharacterLexeme(type: type)
         }


### PR DESCRIPTION
Added support for arcsin(), arccos(), arctan(), exp(), log(), and the exponentiation operation, `^`. Also the `^` operator has higher precedence than `*` and `/`. 

Removed tokenizing of `%` for the time being as it only makes sense for integers and currently only doubles are supported.