### PR TITLE
Updated highlighting scheme

### DIFF
--- a/ScintillaApp/Assets.xcassets/LanguageKeyword.colorset/Contents.json
+++ b/ScintillaApp/Assets.xcassets/LanguageKeyword.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "1.000",
-          "green" : "0.838",
-          "red" : "0.462"
+          "green" : "0.521",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/ScintillaApp/Assets.xcassets/Operator.colorset/Contents.json
+++ b/ScintillaApp/Assets.xcassets/Operator.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "1.000",
-          "green" : "0.838",
-          "red" : "0.462"
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/ScintillaApp/Assets.xcassets/ParameterName.colorset/Contents.json
+++ b/ScintillaApp/Assets.xcassets/ParameterName.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.559",
-          "green" : "0.465",
+          "blue" : "1.000",
+          "green" : "0.590",
           "red" : "0.000"
         }
       },

--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -40,12 +40,16 @@ extension CodeEditor {
     }
 
     private func highlightKeywords(textStorage: NSTextStorage) {
+        let languageKeywords = /\b(?:let|func|true|false|in)\b/
+        let operators = /\+|\-|\*|\/|\^|=/
         // TODO: Need to build these regexes dynamically somehow from ScintillaBuiltin!
-        let worldKeyword = /World/
-        let cameraKeyword = /Camera/
-        let lightKeywords = /AreaLight|PointLight/
-        let shapeKeywords = /ParametricSurface|Plane|Cone|Cube|Cylinder|Group|ImplicitSurface|Prism|Sphere|Superellipsoid|SurfaceOfRevolution|Torus/
+        let worldKeyword = /\bWorld\b/
+        let cameraKeyword = /\bCamera\b/
+        let lightKeywords = /\b(?:AreaLight|PointLight)\b/
+        let shapeKeywords = /\b(?:ParametricSurface|Plane|Cone|Cube|Cylinder|Group|ImplicitSurface|Prism|Sphere|Superellipsoid|SurfaceOfRevolution|Torus)\b/
         let regexColorMappings: [(Regex<Substring>, NSColor)] = [
+            (languageKeywords, NSColor(named: "LanguageKeyword")!),
+            (operators, NSColor(named: "Operator")!),
             (worldKeyword, NSColor(named: "WorldKeyword")!),
             (cameraKeyword, NSColor(named: "CameraKeyword")!),
             (lightKeywords, NSColor(named: "LightKeyword")!),


### PR DESCRIPTION
This PR addresses a few issues:

* It fixes a bug wherein if a keyword is inside another word, it was highlighted nonetheless. The relevant regexes now include word boundaries
* Operators are now highlighted
* Language keywords are now highlighted
* Adjusts some of the existing colors