### PR TITLE
Highlight comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ For instance, the implicit equation for the Barth sextic is:
 The first large term has some repeated patterns, namely the difference of squares. You can refactor that subexpresion out into its own function and incorporate it into the main lambda like this:
 
 ```
+let φ = 1.61833987
+
 func differenceOfSquares(a, b) {
     φ^2*x^2 - y^2
 }
-
-let φ = 1.61833987
 
 let shapes = [
     ImplicitSurface(center: (0.0, 0.0, 0.0),
@@ -197,6 +197,20 @@ tuple          → "(" expression ( "," expression )* ")" ;
 grouping       → "(" expression ")" ;
 list           → "[" expression ( "," expression )* "]" ;
 lambda         → "{" argList "in" expression "}" ;
+```
+
+You can also add comments to your code. They can either be at the end of a line by using two slashes like this:
+
+```
+let answer = 42 // This is an important variable.
+```
+... or you can have comments span multiple lines by using `/*` and `*/` like this:
+
+```
+/*
+ * This is the golden ratio.
+ */
+let φ = 1.61833987
 ```
 
 # Constructing a scene

--- a/ScintillaApp/Assets.xcassets/Comment.colorset/Contents.json
+++ b/ScintillaApp/Assets.xcassets/Comment.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.664",
+          "green" : "0.664",
+          "red" : "0.664"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ScintillaApp/CodeEditor.swift
+++ b/ScintillaApp/CodeEditor.swift
@@ -32,6 +32,8 @@ extension CodeEditor {
             self.highlightNumbers,
             self.highlightMethodNames,
             self.highlightPunctuation,
+            self.highlightEndOfLineComments,
+            self.highlightMultiLineComments,
         ]
 
         for highlighter in highlighters {
@@ -94,6 +96,20 @@ extension CodeEditor {
         self.highlight(layoutManager: layoutManager,
                        regex: punctuationRegex,
                        color: NSColor(named: "Punctuation")!)
+    }
+
+    private func highlightEndOfLineComments(layoutManager: NSLayoutManager) {
+        let commentRegex = /\/\/.*/
+        self.highlight(layoutManager: layoutManager,
+                       regex: commentRegex,
+                       color: NSColor(named: "Comment")!)
+    }
+
+    private func highlightMultiLineComments(layoutManager: NSLayoutManager) {
+        let commentRegex = /\/\*(?:.|\n)*?\*\//
+        self.highlight(layoutManager: layoutManager,
+                       regex: commentRegex,
+                       color: NSColor(named: "Comment")!)
     }
 
     private func highlight<T>(layoutManager: NSLayoutManager,


### PR DESCRIPTION
This PR adds support for proper highlighting of comments in the editor. (The parser already handles both end-of-line and multiline comments.) 
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/ecf5b2b3-c578-4696-b99b-4457b7911256" />
