### PR TITLE
Expose other two parameters for lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,82 @@ World(
 
 ![](./images/two_lights.png)
 
+By default, light sources produce white light but you can override that with a color of your choice. In this example, there are three lights in the scene:
+
+```
+let camera = Camera(
+    width: 400,
+    height: 400,
+    viewAngle: pi/3,
+    from: (0, 2, -5),
+    to: (0, 0, 0),
+    up: (0, 1, 0))
+
+let red = Color(r: 1.0, g: 0.0, b: 0.0)
+let green = Color(r: 0.0, g: 1.0, b: 0.0)
+let blue = Color(r: 0.0, g: 0.0, b: 1.0)
+
+let lights = [
+    PointLight(
+        position: (-5, 5, -5),
+        color: red),
+    PointLight(
+        position: (0, 5, -5),
+        color: blue),
+    PointLight(
+        position: (5, 5, -5),
+        color: green)
+]
+
+let shapes = [
+    Sphere(),
+    Plane()
+        .translate(x: 0.0, y: -1.0, z: 0.0)
+]
+
+World(
+    camera: camera,
+    lights: lights,
+    shapes: shapes)
+```
+
+![](./images/three_colored_lights.png)
+
+Also by default, light intensity does not fade over distance, but if you want a more realistic scene you can specify a value for the `fadeDistance` parameter; larger values mean that light takes more distance to fade, smaller ones result in a sharper dropoff.
+
+```
+let camera = Camera(
+    width: 600,
+    height: 600,
+    viewAngle: pi/3,
+    from: (0, 2, 5),
+    to: (0, 0, 0),
+    up: (0, 1, 0))
+
+let lights = [
+    PointLight(
+        position: (5, 5, 5),
+        fadeDistance: 5.0)
+]
+
+let solidRed = Uniform(
+    Color(r: 1.0, g: 0.0, b: 0.0))
+
+let shapes = [
+    Sphere()
+        .material(solidRed),
+    Plane()
+        .translate(x: 0.0, y: -1.0, z: 0.0)
+]
+
+World(
+    camera: camera,
+    lights: lights,
+    shapes: shapes)
+```
+
+![](./images/faded_light.png)
+
 ## Simple shapes
 
 The following simple geometric shapes are available:

--- a/ScintillaApp.xcodeproj/project.pbxproj
+++ b/ScintillaApp.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.0;
+				MARKETING_VERSION = 0.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.ScintillaApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -461,7 +461,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.0;
+				MARKETING_VERSION = 0.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.ScintillaApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -30,7 +30,10 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case world
     case camera1
     case camera2
-    case pointLight
+    case pointLight1
+    case pointLight2
+    case pointLight3
+    case pointLight4
     case areaLight
     case uniform
     case striped
@@ -122,8 +125,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("Camera", ["width", "height", "viewAngle", "from", "to", "up"])
         case .camera2:
             return .functionName("Camera", ["width", "height", "viewAngle", "from", "to", "up", "antialiasing"])
-        case .pointLight:
+        case .pointLight1:
             return .functionName("PointLight", ["position"])
+        case .pointLight2:
+            return .functionName("PointLight", ["position", "color"])
+        case .pointLight3:
+            return .functionName("PointLight", ["position", "fadeDistance"])
+        case .pointLight4:
+            return .functionName("PointLight", ["position", "color", "fadeDistance"])
         case .areaLight:
             return .functionName("AreaLight", ["corner", "uVector", "uSteps", "vVector", "vSteps"])
         case .uniform:
@@ -313,8 +322,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return try makeCamera(argumentValues: argumentValues)
         case .camera2:
             return try makeCamera(argumentValues: argumentValues)
-        case .pointLight:
-            return try makePointLight(argumentValues: argumentValues)
+        case .pointLight1:
+            return try makePointLight1(argumentValues: argumentValues)
+        case .pointLight2:
+            return try makePointLight2(argumentValues: argumentValues)
+        case .pointLight3:
+            return try makePointLight3(argumentValues: argumentValues)
+        case .pointLight4:
+            return try makePointLight4(argumentValues: argumentValues)
         case .areaLight:
             return try makeAreaLight(argumentValues: argumentValues)
         case .uniform:
@@ -573,11 +588,37 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
                               antialiasing: antialiasing))
     }
 
-    private func makePointLight(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+    private func makePointLight1(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
         let (x, y, z) = try extractRawTuple3(argumentValue: argumentValues[0])
 
         let point = Point(x, y, z)
         return .light(PointLight(position: point))
+    }
+
+    private func makePointLight2(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let (x, y, z) = try extractRawTuple3(argumentValue: argumentValues[0])
+        let point = Point(x, y, z)
+        let color = try extractRawColor(argumentValue: argumentValues[1])
+
+        return .light(PointLight(position: point, color: color))
+    }
+
+    private func makePointLight3(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let (x, y, z) = try extractRawTuple3(argumentValue: argumentValues[0])
+        let point = Point(x, y, z)
+        let fadeDistance = try extractRawDouble(argumentValue: argumentValues[1])
+
+        return .light(PointLight(position: point, fadeDistance: fadeDistance))
+    }
+
+    private func makePointLight4(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let (x, y, z) = try extractRawTuple3(argumentValue: argumentValues[0])
+        let point = Point(x, y, z)
+        let color = try extractRawColor(argumentValue: argumentValues[1])
+        let fadeDistance = try extractRawDouble(argumentValue: argumentValues[2])
+
+        let light = PointLight(position: point, color: color, fadeDistance: fadeDistance)
+        return .light(light)
     }
 
     private func makeAreaLight(argumentValues: [ScintillaValue]) throws -> ScintillaValue {

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -34,7 +34,10 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
     case pointLight2
     case pointLight3
     case pointLight4
-    case areaLight
+    case areaLight1
+    case areaLight2
+    case areaLight3
+    case areaLight4
     case uniform
     case striped
     case gradient
@@ -133,8 +136,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return .functionName("PointLight", ["position", "fadeDistance"])
         case .pointLight4:
             return .functionName("PointLight", ["position", "color", "fadeDistance"])
-        case .areaLight:
+        case .areaLight1:
             return .functionName("AreaLight", ["corner", "uVector", "uSteps", "vVector", "vSteps"])
+        case .areaLight2:
+            return .functionName("AreaLight", ["corner", "uVector", "uSteps", "vVector", "vSteps", "color"])
+        case .areaLight3:
+            return .functionName("AreaLight", ["corner", "uVector", "uSteps", "vVector", "vSteps", "fadeDistance"])
+        case .areaLight4:
+            return .functionName("AreaLight", ["corner", "uVector", "uSteps", "vVector", "vSteps", "color", "fadeDistance"])
         case .uniform:
             return .functionName("Uniform", [""])
         case .striped:
@@ -330,8 +339,14 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             return try makePointLight3(argumentValues: argumentValues)
         case .pointLight4:
             return try makePointLight4(argumentValues: argumentValues)
-        case .areaLight:
-            return try makeAreaLight(argumentValues: argumentValues)
+        case .areaLight1:
+            return try makeAreaLight1(argumentValues: argumentValues)
+        case .areaLight2:
+            return try makeAreaLight2(argumentValues: argumentValues)
+        case .areaLight3:
+            return try makeAreaLight3(argumentValues: argumentValues)
+        case .areaLight4:
+            return try makeAreaLight4(argumentValues: argumentValues)
         case .uniform:
             return try makeUniform(argumentValues: argumentValues)
         case .gradient, .striped, .checkered2D, .checkered3D:
@@ -621,7 +636,31 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         return .light(light)
     }
 
-    private func makeAreaLight(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+    private func makeAreaLight1(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        return try makeAreaLight(argumentValues: argumentValues)
+    }
+
+    private func makeAreaLight2(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let color = try extractRawColor(argumentValue: argumentValues[5])
+        return try makeAreaLight(argumentValues: argumentValues, color: color)
+    }
+
+    private func makeAreaLight3(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let fadeDistance = try extractRawDouble(argumentValue: argumentValues[5])
+        return try makeAreaLight(argumentValues: argumentValues, fadeDistance: fadeDistance)
+    }
+
+    private func makeAreaLight4(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
+        let color = try extractRawColor(argumentValue: argumentValues[5])
+        let fadeDistance = try extractRawDouble(argumentValue: argumentValues[6])
+        return try makeAreaLight(argumentValues: argumentValues,
+                                 color: color,
+                                 fadeDistance: fadeDistance)
+    }
+
+    private func makeAreaLight(argumentValues: [ScintillaValue],
+                               color: Color = .white,
+                               fadeDistance: Double? = nil) throws -> ScintillaValue {
         let (cornerX, cornerY, cornerZ) = try extractRawTuple3(argumentValue: argumentValues[0])
         let corner = Point(cornerX, cornerY, cornerZ)
         let (uVectorX, uVectorY, uVectorZ) = try extractRawTuple3(argumentValue: argumentValues[1])
@@ -631,13 +670,17 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
         let vVector = Vector(vVectorX, vVectorY, vVectorZ)
         let vSteps = Int(try extractRawDouble(argumentValue: argumentValues[4]))
 
-        return .light(AreaLight(
+        let light = AreaLight(
             corner: corner,
+            color: color,
             uVec: uVector,
             uSteps: uSteps,
             vVec: vVector,
-            vSteps: vSteps))
+            vSteps: vSteps,
+            fadeDistance: fadeDistance)
+        return .light(light)
     }
+
 
     private func makeUniform(argumentValues: [ScintillaValue]) throws -> ScintillaValue {
         let color = try extractRawColor(argumentValue: argumentValues[0])

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -223,7 +223,7 @@ World(
                                         Token(
                                             type: .identifier,
                                             lexeme: makeLexeme(source: source, offset: 69, length: 2)),
-                                        ResolvedLocation(depth: 0, index: 65)),
+                                        ResolvedLocation(depth: 0, index: 71)),
                                     Token(
                                         type: .slash,
                                         lexeme: makeLexeme(source: source, offset: 71, length: 1)),
@@ -361,7 +361,7 @@ World(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 208, length: 7)),
                             [nil],
-                            ResolvedLocation(depth: 0, index: 21)),
+                            ResolvedLocation(depth: 0, index: 27)),
                         Token(
                             type: .leftParen,
                             lexeme: makeLexeme(source: source, offset: 215, length: 1)),
@@ -454,7 +454,7 @@ World(
                                             Token(
                                                 type: .identifier,
                                                 lexeme: makeLexeme(source: source, offset: 299, length: 9)),
-                                            ResolvedLocation(depth: 0, index: 68)))
+                                            ResolvedLocation(depth: 0, index: 74)))
                                 ])
                         ])),
             ],
@@ -487,7 +487,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 332, length: 6)),
-                            ResolvedLocation(depth: 0, index: 66))),
+                            ResolvedLocation(depth: 0, index: 72))),
                     Expression<ResolvedLocation>.Argument(
                         name: Token(
                             type: .identifier,
@@ -496,7 +496,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 352, length: 6)),
-                            ResolvedLocation(depth: 0, index: 67))),
+                            ResolvedLocation(depth: 0, index: 73))),
                     Expression<ResolvedLocation>.Argument(
                         name: Token(
                             type: .identifier,
@@ -505,7 +505,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 372, length: 6)),
-                            ResolvedLocation(depth: 0, index: 69))),
+                            ResolvedLocation(depth: 0, index: 75))),
                 ])
         )
 


### PR DESCRIPTION
This PR exposes the `color` and `fadeDistance` parameters for both `PointLight` and `AreaLight`. 

I could have taken a more thorough approach wherein I solved the general problem of supporting optional parameters for builtin and/or user-defined functions and constructors, but I decided that at this time there is not a compelling case to support that feature in this tiny programming language. And so, I resorted to "registering" all of the possible combinations of parameters that can be passed to the constructors of `PointLight` and `AreaLight`. 

Unit tests and the README were also updated accordingly.