### PR TITLE
Introduce list iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,25 @@ let ball = Sphere().translate(x: 2.0, y: 0.0, z: 0.0)
 ```
 ... where the value for the `x` parameter is `2.0`, the `y` parameter 0.0, and the `z` parameter 0.0. More detailed discussion of other methods is given below in the Shapes section.
 
+Lists also have two methods for iterating over them, `each()` and `eachWithIndex()`, each of which take a closure to transform each element of the list, the latter of which also includes the index as one of its parameters. As an example, in this code snippet we construct a list of materials representing the solid colors red, green, and blue, then iterate over them to produce a list of `Sphere`s each assigned to a color and also translated a distinct number of units along the x-axis:
+
+```
+let red = Uniform(Color(r: 1.0, g: 0.0, b: 0.0))
+let green = Uniform(Color(r: 0.0, g: 1.0, b: 0.0))
+let blue = Uniform(Color(r: 0.0, g: 0.0, b: 1.0))
+
+let colors = [red, green, blue]
+
+let shapes = colors.eachWithIndex({i, color in
+    Sphere()
+        .material(color)
+        .translate(x: i-1, y: 0.0, z: 0.0)
+})
+```
+
 The language supports most of the primitive types, operators and means of constructing expressions that many other programming languages have, including:
 
-* a boolean type for the few shapes that take them as parameters, whosw possible values are `true` and `false`
+* a boolean type for the few shapes that take them as parameters, whose possible values are `true` and `false`
 * a double numeric type; integer literals are cast as doubles
 * lists of values, bounded by `[` and `]` with `,` as the delimiter
 * tuples of values, bounded by `(` and `)` with `,` as the delimiter
@@ -367,7 +383,7 @@ There is also a `SpotLight` available which you can use to illuminate a focused 
 
 Below is an example of a scene with a spot light up and to the left of the red ball, which results in the ball's shadow being cast within the elliptical region on the plane illuminated by the spot light:
 
-```
+```swift
 let camera = Camera(
     width: 400,
     height: 400,
@@ -443,7 +459,7 @@ World(
 
 By default, light sources produce white light but you can override that with a color of your choice. In this example, there are three lights in the scene:
 
-```
+```swift
 let camera = Camera(
     width: 400,
     height: 400,
@@ -484,7 +500,7 @@ World(
 
 Also by default, light intensity does not fade over distance, but if you want a more realistic scene you can specify a value for the `fadeDistance` parameter; larger values mean that light takes more distance to fade, smaller ones result in a sharper dropoff.
 
-```
+```swift
 let camera = Camera(
     width: 600,
     height: 600,

--- a/ScintillaApp.xcodeproj/project.pbxproj
+++ b/ScintillaApp.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.3;
+				MARKETING_VERSION = 0.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.ScintillaApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -461,7 +461,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.3;
+				MARKETING_VERSION = 0.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.ScintillaApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -260,7 +260,9 @@ class Evaluator {
         }
 
         if case .boundMethod(let callee, let builtin) = callee {
-            return try builtin.callMethod(object: callee, argumentValues: argumentValues)
+            return try builtin.callMethod(evaluator: self,
+                                          object: callee,
+                                          argumentValues: argumentValues)
         }
 
         if case .userDefinedFunction(let userDefinedFunction) = callee {

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -39,6 +39,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
     case couldNotEvaluateFunction(Token)
     case couldNotConstructLambda(Token)
     case notAPureMathFunction(ObjectName)
+    case closureHasWrongArity(Int, Int)
 
     var description: String {
         switch self {
@@ -102,6 +103,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
             return "[\(exprToken.location)] Error: could not construct lambda, \(exprToken.lexeme)"
         case .notAPureMathFunction(let objectName):
             return "[\(objectName.location())] Error: not a pure mathematical function, \(objectName)"
+        case .closureHasWrongArity(let expectedArity, let actualArity):
+            return "[] Error: closure has wrong arity; expected \(expectedArity) arguments, got \(actualArity)"
         }
     }
 }

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -14,7 +14,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
     case unsupportedUnaryOperator(SourceLocation, Substring)
     case unaryOperandMustBeNumber(SourceLocation, Substring)
     case unsupportedBinaryOperator(SourceLocation, Substring)
-    case binaryOperandsMustBeNumbers(SourceLocation, Substring)
+    case binaryOperandsMustBeNumbersOrLists(SourceLocation, Substring)
     case notAFunction(SourceLocation, Substring)
     case notCallable(SourceLocation, Substring)
     // TODO: Need to capture location and lexemes for the following three error cases
@@ -54,7 +54,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
             return "[\(location)] Error: unary operand must be number, \(badOperator)"
         case .unsupportedBinaryOperator(let location, let badOperator):
             return "[\(location)] Error: unsupported binary operator, \(badOperator)"
-        case .binaryOperandsMustBeNumbers(let location, let badOperator):
+        case .binaryOperandsMustBeNumbersOrLists(let location, let badOperator):
             return "[\(location)] Error: binary operands must be numbers, \(badOperator)"
         case .notAFunction(let location, let badFunction):
             return "[\(location)] Error: not a function, \(badFunction)"

--- a/ScintillaAppTests/EvaluatorTests.swift
+++ b/ScintillaAppTests/EvaluatorTests.swift
@@ -225,7 +225,7 @@ let blue = Uniform(Color(r: 0.0, g: 0.0, b: 1.0))
 
 let colors = [red, green, blue]
 
-colors.each({i, color in
+colors.eachWithIndex({i, color in
     Sphere()
         .material(color)
         .translate(x: i-1, y: 0.0, z: 0.0)

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -223,7 +223,7 @@ World(
                                         Token(
                                             type: .identifier,
                                             lexeme: makeLexeme(source: source, offset: 69, length: 2)),
-                                        ResolvedLocation(depth: 0, index: 78)),
+                                        ResolvedLocation(depth: 0, index: 79)),
                                     Token(
                                         type: .slash,
                                         lexeme: makeLexeme(source: source, offset: 71, length: 1)),
@@ -454,7 +454,7 @@ World(
                                             Token(
                                                 type: .identifier,
                                                 lexeme: makeLexeme(source: source, offset: 299, length: 9)),
-                                            ResolvedLocation(depth: 0, index: 81)))
+                                            ResolvedLocation(depth: 0, index: 82)))
                                 ])
                         ])),
             ],
@@ -487,7 +487,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 332, length: 6)),
-                            ResolvedLocation(depth: 0, index: 79))),
+                            ResolvedLocation(depth: 0, index: 80))),
                     Expression<ResolvedLocation>.Argument(
                         name: Token(
                             type: .identifier,
@@ -496,7 +496,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 352, length: 6)),
-                            ResolvedLocation(depth: 0, index: 80))),
+                            ResolvedLocation(depth: 0, index: 81))),
                     Expression<ResolvedLocation>.Argument(
                         name: Token(
                             type: .identifier,
@@ -505,7 +505,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 372, length: 6)),
-                            ResolvedLocation(depth: 0, index: 82))),
+                            ResolvedLocation(depth: 0, index: 83))),
                 ])
         )
 

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -223,7 +223,7 @@ World(
                                         Token(
                                             type: .identifier,
                                             lexeme: makeLexeme(source: source, offset: 69, length: 2)),
-                                        ResolvedLocation(depth: 0, index: 75)),
+                                        ResolvedLocation(depth: 0, index: 78)),
                                     Token(
                                         type: .slash,
                                         lexeme: makeLexeme(source: source, offset: 71, length: 1)),
@@ -454,7 +454,7 @@ World(
                                             Token(
                                                 type: .identifier,
                                                 lexeme: makeLexeme(source: source, offset: 299, length: 9)),
-                                            ResolvedLocation(depth: 0, index: 78)))
+                                            ResolvedLocation(depth: 0, index: 81)))
                                 ])
                         ])),
             ],
@@ -487,7 +487,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 332, length: 6)),
-                            ResolvedLocation(depth: 0, index: 76))),
+                            ResolvedLocation(depth: 0, index: 79))),
                     Expression<ResolvedLocation>.Argument(
                         name: Token(
                             type: .identifier,
@@ -496,7 +496,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 352, length: 6)),
-                            ResolvedLocation(depth: 0, index: 77))),
+                            ResolvedLocation(depth: 0, index: 80))),
                     Expression<ResolvedLocation>.Argument(
                         name: Token(
                             type: .identifier,
@@ -505,7 +505,7 @@ World(
                             Token(
                                 type: .identifier,
                                 lexeme: makeLexeme(source: source, offset: 372, length: 6)),
-                            ResolvedLocation(depth: 0, index: 79))),
+                            ResolvedLocation(depth: 0, index: 82))),
                 ])
         )
 


### PR DESCRIPTION
This PR introduces list iteration and concatenation. Two new methods to lists have been added, namely `each()` and `eachWithIndex()`, both of which take a closure to produce a new list, the latter which takes an index parameter. A new `RuntimeError` case has been added and is thrown whenever the closure passed to either new method takes the wrong number of parameters. Unit tests and the README have been updated accordingly.