### PR TITLE
Introduce destructuring

### DIFF
--- a/ScintillaApp.xcodeproj/project.pbxproj
+++ b/ScintillaApp.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.ScintillaApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -461,7 +461,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quephird.ScintillaApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ScintillaApp/AssignmentPattern.swift
+++ b/ScintillaApp/AssignmentPattern.swift
@@ -1,0 +1,13 @@
+//
+//  AssignmentPattern.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 4/25/25.
+//
+
+enum AssignmentPattern: Equatable {
+    case variable(Token)
+    indirect case tuple2(AssignmentPattern, AssignmentPattern)
+    indirect case tuple3(AssignmentPattern, AssignmentPattern, AssignmentPattern)
+    // TODO FROM BECCA: Support underscore placeholders
+}

--- a/ScintillaApp/AssignmentPattern.swift
+++ b/ScintillaApp/AssignmentPattern.swift
@@ -6,8 +6,8 @@
 //
 
 enum AssignmentPattern: Equatable {
+    case wildcard(Token)
     case variable(Token)
     indirect case tuple2(AssignmentPattern, AssignmentPattern)
     indirect case tuple3(AssignmentPattern, AssignmentPattern, AssignmentPattern)
-    // TODO FROM BECCA: Support underscore placeholders
 }

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -101,6 +101,8 @@ class Evaluator {
                               value: ScintillaValue,
                               environment: Environment) throws {
         switch pattern {
+        case .wildcard:
+            break
         case .variable(let nameToken):
             let name: ObjectName = .variableName(nameToken.lexeme)
             environment.define(name: name, value: value)

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -92,14 +92,35 @@ class Evaluator {
     private func handleLetDeclaration(lhsPattern: AssignmentPattern,
                                       equalsToken: Token,
                                       rhsExpr: Expression<ResolvedLocation>) throws {
-        switch lhsPattern {
-        case .variable(let nameToken):
-            let value = try evaluate(expr: rhsExpr)
+        let value = try evaluate(expr: rhsExpr)
 
+        try handlePattern(pattern: lhsPattern, value: value)
+    }
+
+    private func handlePattern(pattern: AssignmentPattern, value: ScintillaValue) throws {
+        switch pattern {
+        case .variable(let nameToken):
             let name: ObjectName = .variableName(nameToken.lexeme)
             environment.define(name: name, value: value)
-        default:
-            fatalError("Not handled yet!!!")
+        case .tuple2(let pattern1, let pattern2):
+            guard case .tuple2((let value1, let value2)) = value else {
+                throw RuntimeError.expectedTuplePattern(2)
+            }
+
+            for (pattern, value) in [(pattern1, value1),
+                                     (pattern2, value2)] {
+                try handlePattern(pattern: pattern, value: value)
+            }
+        case .tuple3(let pattern1, let pattern2, let pattern3):
+            guard case .tuple3((let value1, let value2, let value3)) = value else {
+                throw RuntimeError.expectedTuplePattern(3)
+            }
+
+            for (pattern, value) in [(pattern1, value1),
+                                     (pattern2, value2),
+                                     (pattern3, value3)] {
+                try handlePattern(pattern: pattern, value: value)
+            }
         }
     }
 

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -75,8 +75,10 @@ class Evaluator {
 
     func execute(statement: Statement<ResolvedLocation>) throws {
         switch statement {
-        case .letDeclaration(let nameToken, let expr):
-            try handleLetDeclaration(nameToken: nameToken, expr: expr)
+        case .letDeclaration(let lhsPattern, let equalsToken, let rhsExpr):
+            try handleLetDeclaration(lhsPattern: lhsPattern,
+                                     equalsToken: equalsToken,
+                                     rhsExpr: rhsExpr)
         case .functionDeclaration(let nameToken, let argumentNames, let letDecls, let returnExpr):
             try handleFunctionDeclaration(nameToken: nameToken,
                                           argumentNames: argumentNames,
@@ -87,11 +89,18 @@ class Evaluator {
         }
     }
 
-    private func handleLetDeclaration(nameToken: Token, expr: Expression<ResolvedLocation>) throws {
-        let value = try evaluate(expr: expr)
+    private func handleLetDeclaration(lhsPattern: AssignmentPattern,
+                                      equalsToken: Token,
+                                      rhsExpr: Expression<ResolvedLocation>) throws {
+        switch lhsPattern {
+        case .variable(let nameToken):
+            let value = try evaluate(expr: rhsExpr)
 
-        let name: ObjectName = .variableName(nameToken.lexeme)
-        environment.define(name: name, value: value)
+            let name: ObjectName = .variableName(nameToken.lexeme)
+            environment.define(name: name, value: value)
+        default:
+            fatalError("Not handled yet!!!")
+        }
     }
 
     private func handleFunctionDeclaration(nameToken: Token,

--- a/ScintillaApp/Evaluator.swift
+++ b/ScintillaApp/Evaluator.swift
@@ -158,8 +158,9 @@ class Evaluator {
             return try handleFunction(calleeToken: calleeName,
                                       argumentNameTokens: argumentNames,
                                       location: location)
-        case .lambda(_, let argumentNames, let expression):
+        case .lambda(_, let argumentNames, let letDecls, let expression):
             return try handleLambda(argumentNames: argumentNames,
+                                    letDecls: letDecls,
                                     expression: expression)
         case .method(let calleeExpr, let methodToken, let argumentNameTokens):
             return try handleMethod(calleeExpr: calleeExpr,
@@ -351,11 +352,12 @@ class Evaluator {
     }
 
     private func handleLambda(argumentNames: [Token],
+                              letDecls: [Statement<ResolvedLocation>],
                               expression: Expression<ResolvedLocation>) throws -> ScintillaValue {
         let udf = UserDefinedFunction(name: "",
                                       argumentNames: argumentNames,
                                       enclosingEnvironment: self.environment,
-                                      letDecls: [],
+                                      letDecls: letDecls,
                                       returnExpr: expression)
 
         return .lambda(udf)

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -29,7 +29,7 @@ indirect enum Expression<Location: Equatable>: Equatable {
     //
     // * Builtin methods of Scintilla objects, such as `Shape.translate()`, `Shape.rotateX()`, etc.
     case method(Expression, Token, [Token?])
-    case lambda(Token, [Token], [Statement<Location>], Expression)
+    case lambda(Token, [Parameter], [Statement<Location>], Expression)
     case call(Expression, Token, [Argument])
 
     var locationToken: Token {

--- a/ScintillaApp/Expression.swift
+++ b/ScintillaApp/Expression.swift
@@ -29,7 +29,7 @@ indirect enum Expression<Location: Equatable>: Equatable {
     //
     // * Builtin methods of Scintilla objects, such as `Shape.translate()`, `Shape.rotateX()`, etc.
     case method(Expression, Token, [Token?])
-    case lambda(Token, [Token], Expression)
+    case lambda(Token, [Token], [Statement<Location>], Expression)
     case call(Expression, Token, [Argument])
 
     var locationToken: Token {
@@ -52,7 +52,7 @@ indirect enum Expression<Location: Equatable>: Equatable {
             return leftParenToken
         case .function(let nameToken, _, _):
             return nameToken
-        case .lambda(let leftBraceToken, _, _):
+        case .lambda(let leftBraceToken, _, _, _):
             return leftBraceToken
         case .method(_, let methodNameToken, _):
             return methodNameToken

--- a/ScintillaApp/Parameter.swift
+++ b/ScintillaApp/Parameter.swift
@@ -1,0 +1,11 @@
+//
+//  Parameter.swift
+//  ScintillaApp
+//
+//  Created by Danielle Kefford on 4/28/25.
+//
+
+public struct Parameter: Equatable {
+    var name: Token?
+    var pattern: AssignmentPattern
+}

--- a/ScintillaApp/ParseError.swift
+++ b/ScintillaApp/ParseError.swift
@@ -9,7 +9,9 @@ import Foundation
 
 enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingVariableName(Token)
+    case missingParameterName(Token)
     case missingPattern(Token)
+    case missingAs(Token)
     case missingFunctionName(Token)
     case missingEquals(Token)
     case missingLeftParen(Token)
@@ -27,8 +29,12 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
         switch self {
         case .missingVariableName(let token):
             return "[\(token.location)] Error: expected variable name"
+        case .missingParameterName(let token):
+            return "[\(token.location)] Error: expected parameter name"
         case .missingPattern(let token):
             return "[\(token.location)] Error: expected variable or tuple pattern"
+        case .missingAs(let token):
+            return "[\(token.location)] Error: expected keyword `as`"
         case .missingFunctionName(let token):
             return "[\(token.location)] Error: expected function name"
         case .missingEquals(let token):

--- a/ScintillaApp/ParseError.swift
+++ b/ScintillaApp/ParseError.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingVariableName(Token)
+    case missingPattern(Token)
     case missingFunctionName(Token)
     case missingEquals(Token)
     case missingLeftParen(Token)
@@ -26,6 +27,8 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
         switch self {
         case .missingVariableName(let token):
             return "[\(token.location)] Error: expected variable name"
+        case .missingPattern(let token):
+            return "[\(token.location)] Error: expected variable or tuple pattern"
         case .missingFunctionName(let token):
             return "[\(token.location)] Error: expected function name"
         case .missingEquals(let token):

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -421,13 +421,18 @@ extension Parser {
             throw ParseError.missingIn(currentToken)
         }
 
+        var letDecls: [Statement<UnresolvedLocation>] = []
+        while let letDecl = try parseLetDeclaration() {
+            letDecls.append(letDecl)
+        }
+
         let expression = try parseExpression()
 
         guard currentTokenMatchesAny(types: [.rightBrace]) else {
             throw ParseError.missingRightBrace(currentToken)
         }
 
-        return .lambda(leftBrace, argumentNames, expression)
+        return .lambda(leftBrace, argumentNames, letDecls, expression)
     }
 
     mutating private func parseArguments() throws -> [Expression<UnresolvedLocation>.Argument] {

--- a/ScintillaApp/Parser.swift
+++ b/ScintillaApp/Parser.swift
@@ -164,6 +164,8 @@ extension Parser {
             }
 
             return .tuple3(pattern1, pattern2, pattern3)
+        } else if currentTokenMatchesAny(types: [.underscore]) {
+            return .wildcard(previousToken)
         } else {
             guard let varName = consumeToken(type: .identifier) else {
                 throw ParseError.missingVariableName(currentToken)
@@ -194,6 +196,8 @@ extension Parser {
 
             let parameter: Parameter
             switch pattern {
+            case .wildcard(let wildToken):
+                parameter = Parameter(name: wildToken, pattern: pattern)
             case .variable(let nameToken):
                 parameter = Parameter(name: nameToken, pattern: pattern)
             case .tuple2, .tuple3:

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -168,6 +168,8 @@ extension Resolver {
 
     mutating private func handlePattern(pattern: AssignmentPattern) throws {
         switch pattern {
+        case .wildcard:
+            break
         case .variable(let nameToken):
             try declareVariable(variableToken: nameToken)
             defineVariable(variableToken: nameToken)

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -142,8 +142,10 @@ extension Resolver {
 
     mutating public func resolve(statement: Statement<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
         switch statement {
-        case .letDeclaration(let nameToken, let initializeExpr):
-            return try handleLetDeclaration(nameToken: nameToken, initializeExpr: initializeExpr)
+        case .letDeclaration(let lhsPattern, let equalsToken, let rhsExpr):
+            return try handleLetDeclaration(lhsPattern: lhsPattern,
+                                            equalsToken: equalsToken,
+                                            rhsExpr: rhsExpr)
         case .functionDeclaration(let nameToken, let argumentNames, let letDecls, let returnExpr):
             return try handleFunctionDeclaration(nameToken: nameToken,
                                                  argumentNames: argumentNames,
@@ -154,14 +156,21 @@ extension Resolver {
         }
     }
 
-    mutating private func handleLetDeclaration(nameToken: Token,
-                                               initializeExpr: Expression<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
-        try declareVariable(variableToken: nameToken)
+    mutating private func handleLetDeclaration(lhsPattern: AssignmentPattern,
+                                               equalsToken: Token,
+                                               rhsExpr: Expression<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
+        switch lhsPattern {
+        case .variable(let nameToken):
+            try declareVariable(variableToken: nameToken)
 
-        let resolvedInitializerExpr = try resolve(expression: initializeExpr)
+            let resolvedRhsExpr = try resolve(expression: rhsExpr)
 
-        defineVariable(variableToken: nameToken)
-        return .letDeclaration(nameToken, resolvedInitializerExpr)
+            defineVariable(variableToken: nameToken)
+
+            return .letDeclaration(lhsPattern, equalsToken, resolvedRhsExpr)
+        default:
+            fatalError("Not handled right now!!!")
+        }
     }
 
     mutating private func handleFunctionDeclaration(nameToken: Token,

--- a/ScintillaApp/Resolver.swift
+++ b/ScintillaApp/Resolver.swift
@@ -159,17 +159,26 @@ extension Resolver {
     mutating private func handleLetDeclaration(lhsPattern: AssignmentPattern,
                                                equalsToken: Token,
                                                rhsExpr: Expression<UnresolvedLocation>) throws -> Statement<ResolvedLocation> {
-        switch lhsPattern {
+        let resolvedRhsExpr = try resolve(expression: rhsExpr)
+
+        try handlePattern(pattern: lhsPattern)
+
+        return .letDeclaration(lhsPattern, equalsToken, resolvedRhsExpr)
+    }
+
+    mutating private func handlePattern(pattern: AssignmentPattern) throws {
+        switch pattern {
         case .variable(let nameToken):
             try declareVariable(variableToken: nameToken)
-
-            let resolvedRhsExpr = try resolve(expression: rhsExpr)
-
             defineVariable(variableToken: nameToken)
-
-            return .letDeclaration(lhsPattern, equalsToken, resolvedRhsExpr)
-        default:
-            fatalError("Not handled right now!!!")
+        case .tuple2(let pattern1, let pattern2):
+            for pattern in [pattern1, pattern2] {
+                try handlePattern(pattern: pattern)
+            }
+        case .tuple3(let pattern1, let pattern2, let pattern3):
+            for pattern in [pattern1, pattern2, pattern3] {
+                try handlePattern(pattern: pattern)
+            }
         }
     }
 

--- a/ScintillaApp/ResolverError.swift
+++ b/ScintillaApp/ResolverError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum ResolverError: LocalizedError, CustomStringConvertible {
     case undefinedVariable(Token)
     case undefinedFunction(Token)
+    case missingParameterName(Token)
     case incorrectArgumentsForFunction(Token)
     case variableAccessedBeforeInitialization(Token)
     case variableAlreadyDefined(ObjectName)
@@ -20,6 +21,8 @@ enum ResolverError: LocalizedError, CustomStringConvertible {
             return "[\(token.location)] Error: undefined variable, \(token.lexeme)"
         case .undefinedFunction(let token):
             return "[\(token.location)] Error: undefined function, \(token.lexeme)"
+        case .missingParameterName(let token):
+            return "[\(token.location)] Error: user-defined functions must have parameter names"
         case .incorrectArgumentsForFunction(let token):
             return "[\(token.location)] Error: incorrect arguments for function, \(token.lexeme)"
         case .variableAccessedBeforeInitialization(let token):

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -18,6 +18,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
     case notAFunction(SourceLocation, Substring)
     case notCallable(SourceLocation, Substring)
     // TODO: Need to capture location and lexemes for the following three error cases
+    case missingParameterName(Token)
     case missingArgumentName(Token)
     case incorrectArgument
     case incorrectObject
@@ -62,6 +63,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
             return "[\(location)] Error: not a function, \(badFunction)"
         case .notCallable(let location, let badObject):
             return "[\(location)] Error: not a function, \(badObject)"
+        case .missingParameterName(let token):
+            return "[\(token.location)] Error: missing parameter name for function"
         case .missingArgumentName(let token):
             return "[\(token.location)] Error: missing argument for method, \(token.lexeme)"
         case .incorrectArgument:

--- a/ScintillaApp/RuntimeError.swift
+++ b/ScintillaApp/RuntimeError.swift
@@ -40,6 +40,7 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
     case couldNotConstructLambda(Token)
     case notAPureMathFunction(ObjectName)
     case closureHasWrongArity(Int, Int)
+    case expectedTuplePattern(Int)
 
     var description: String {
         switch self {
@@ -105,6 +106,8 @@ enum RuntimeError: LocalizedError, CustomStringConvertible, Equatable {
             return "[\(objectName.location())] Error: not a pure mathematical function, \(objectName)"
         case .closureHasWrongArity(let expectedArity, let actualArity):
             return "[] Error: closure has wrong arity; expected \(expectedArity) arguments, got \(actualArity)"
+        case .expectedTuplePattern(let elementCount):
+            return "[] Error: expected a \(elementCount)-tuple on the right hand side of let statement"
         }
     }
 }

--- a/ScintillaApp/ScintillaBuiltin.swift
+++ b/ScintillaApp/ScintillaBuiltin.swift
@@ -1077,8 +1077,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             throw RuntimeError.expectedLambda
         }
 
-        guard lambda.argumentNames.count == 1 else {
-            throw RuntimeError.closureHasWrongArity(1, lambda.argumentNames.count)
+        guard lambda.parameters.count == 1 else {
+            throw RuntimeError.closureHasWrongArity(1, lambda.parameters.count)
         }
 
         let results: [ScintillaValue] = try elements.map { element in
@@ -1100,8 +1100,8 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             throw RuntimeError.expectedLambda
         }
 
-        guard lambda.argumentNames.count == 2 else {
-            throw RuntimeError.closureHasWrongArity(2, lambda.argumentNames.count)
+        guard lambda.parameters.count == 2 else {
+            throw RuntimeError.closureHasWrongArity(2, lambda.parameters.count)
         }
 
         let results: [ScintillaValue] = try elements.enumerated().map { index, element in
@@ -1250,7 +1250,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             throw RuntimeError.expectedUserDefinedFunction
         }
 
-        guard udf.argumentNames.count == 3 else {
+        guard udf.parameters.count == 3 else {
             throw RuntimeError.implicitSurfaceLambdaWrongArity
         }
 
@@ -1264,7 +1264,7 @@ enum ScintillaBuiltin: CaseIterable, Equatable {
             throw RuntimeError.expectedUserDefinedFunction
         }
 
-        guard udf.argumentNames.count == 2 else {
+        guard udf.parameters.count == 2 else {
             throw RuntimeError.parametricSurfaceLambdaWrongArity
         }
 

--- a/ScintillaApp/Statement.swift
+++ b/ScintillaApp/Statement.swift
@@ -6,14 +6,14 @@
 //
 
 enum Statement<Location: Equatable>: Equatable {
-    case letDeclaration(Token, Expression<Location>)
+    case letDeclaration(AssignmentPattern, Token, Expression<Location>)
     case functionDeclaration(Token, [Token], [Statement<Location>], Expression<Location>)
     case expression(Expression<Location>)
 
     var locationToken: Token {
         switch self {
-        case .letDeclaration(let nameToken, _):
-            return nameToken
+        case .letDeclaration(_, let equalsToken, _):
+            return equalsToken
         case .functionDeclaration(let nameToken, _, _, _):
             return nameToken
         case .expression(let expr):

--- a/ScintillaApp/Statement.swift
+++ b/ScintillaApp/Statement.swift
@@ -7,7 +7,7 @@
 
 enum Statement<Location: Equatable>: Equatable {
     case letDeclaration(AssignmentPattern, Token, Expression<Location>)
-    case functionDeclaration(Token, [Token], [Statement<Location>], Expression<Location>)
+    case functionDeclaration(Token, [Parameter], [Statement<Location>], Expression<Location>)
     case expression(Expression<Location>)
 
     var locationToken: Token {

--- a/ScintillaApp/TokenType.swift
+++ b/ScintillaApp/TokenType.swift
@@ -33,6 +33,7 @@ enum TokenType: Equatable {
     case `in`
     case `let`
     case `true`
+    case `as`
 
     // Used for bad tokens
     case unknown

--- a/ScintillaApp/TokenType.swift
+++ b/ScintillaApp/TokenType.swift
@@ -23,6 +23,9 @@ enum TokenType: Equatable {
     case slash
     case caret
 
+    // Special case
+    case underscore
+
     // Literals
     case identifier
     case double

--- a/ScintillaApp/Tokenizer.swift
+++ b/ScintillaApp/Tokenizer.swift
@@ -126,6 +126,10 @@ struct Tokenizer {
             return try handleSlash()
         }
 
+        if tryScan("_") {
+            return try handleUnderscore()
+        }
+
         if tryScan(" ", "\r", "\t") {
             return
         }
@@ -138,7 +142,7 @@ struct Tokenizer {
             return try handleNumber()
         }
 
-        if tryScan(where: { $0.isLetter || $0 == "_" }) {
+        if tryScan(where: { $0.isLetter }) {
             return try handleIdentifier()
         }
 
@@ -163,6 +167,14 @@ struct Tokenizer {
         } else {
             handleSingleCharacterLexeme(type: .slash)
         }
+    }
+
+    mutating private func handleUnderscore() throws {
+        if tryScan(where: { $0.isLetter }) {
+            return try handleIdentifier()
+        }
+
+        addToken(type: .underscore)
     }
 
     mutating private func handleNumber() throws {

--- a/ScintillaApp/Tokenizer.swift
+++ b/ScintillaApp/Tokenizer.swift
@@ -18,6 +18,7 @@ struct Tokenizer {
         "in": .in,
         "let": .let,
         "true": .true,
+        "as": .as
     ]
 
     init(source: String) {

--- a/ScintillaAppTests/EvaluatorTests.swift
+++ b/ScintillaAppTests/EvaluatorTests.swift
@@ -272,6 +272,22 @@ colors.eachWithIndex({i, color in
         }
     }
 
+    @Test func testFunctionWithDestructuredParameter() async throws {
+        let source = """
+func foo(a, (b, c) as d) {
+    a + b + c
+}
+
+foo(a: 1, d: (2, 3))
+"""
+
+        let evaluator = Evaluator()
+        let actualResult = try evaluator.interpretRaw(source: source)
+        let expectedResult: ScintillaValue = .double(Double(6))
+
+        #expect(actualResult == expectedResult)
+    }
+
     @Test func evaluateMinimalProgram() async throws {
         let source = """
 let camera = Camera(

--- a/ScintillaAppTests/EvaluatorTests.swift
+++ b/ScintillaAppTests/EvaluatorTests.swift
@@ -318,6 +318,22 @@ foo(a: 1, e: (2, (3, 4)))
         #expect(actualResult == expectedResult)
     }
 
+    @Test func testFunctionWithWildcard() async throws {
+        let source = """
+func foo(a, (b, (_, c)) as e) {
+    a + b + c
+}
+
+foo(a: 1, e: (2, (3, 4)))
+"""
+
+        let evaluator = Evaluator()
+        let actualResult = try evaluator.interpretRaw(source: source)
+        let expectedResult: ScintillaValue = .double(Double(7))
+
+        #expect(actualResult == expectedResult)
+    }
+
     @Test func testLambdaWithDestructuring() async throws {
         let source = """
 let argeebees = [

--- a/ScintillaAppTests/EvaluatorTests.swift
+++ b/ScintillaAppTests/EvaluatorTests.swift
@@ -272,7 +272,21 @@ colors.eachWithIndex({i, color in
         }
     }
 
-    @Test func testFunctionWithDestructuredParameter() async throws {
+    @Test func testLetStatementWithDestructuring() async throws {
+        let source = """
+let (a, (b, (c, d))) = (1, (2, (3, 4)))
+
+a + b + c
+"""
+
+        let evaluator = Evaluator()
+        let actualResult = try evaluator.interpretRaw(source: source)
+        let expectedResult: ScintillaValue = .double(Double(6))
+
+        #expect(actualResult == expectedResult)
+    }
+
+    @Test func testFunctionWithDestructuring() async throws {
         let source = """
 func foo(a, (b, c) as d) {
     a + b + c
@@ -285,6 +299,48 @@ foo(a: 1, d: (2, 3))
         let actualResult = try evaluator.interpretRaw(source: source)
         let expectedResult: ScintillaValue = .double(Double(6))
 
+        #expect(actualResult == expectedResult)
+    }
+
+    @Test func testFunctionWithNestedDestructuring() async throws {
+        let source = """
+func foo(a, (b, (c, d)) as e) {
+    a + b + c
+}
+
+foo(a: 1, e: (2, (3, 4)))
+"""
+
+        let evaluator = Evaluator()
+        let actualResult = try evaluator.interpretRaw(source: source)
+        let expectedResult: ScintillaValue = .double(Double(6))
+
+        #expect(actualResult == expectedResult)
+    }
+
+    @Test func testLambdaWithDestructuring() async throws {
+        let source = """
+let argeebees = [
+    (1, 0, 0),
+    (0, 1, 0),
+    (0, 0, 1)
+]
+
+let colors = argeebees.each({ (r, g, b) in
+   Uniform(Color(r: r, g: g, b: b))
+})
+
+colors
+"""
+
+        let evaluator = Evaluator()
+        let result = try evaluator.interpretRaw(source: source)
+        let actualResult = try #require(result.getList())
+        let expectedResult: [ScintillaValue] = [
+            .material(Uniform(Color(1, 0, 0))),
+            .material(Uniform(Color(0, 1, 0))),
+            .material(Uniform(Color(0, 0, 1))),
+        ]
         #expect(actualResult == expectedResult)
     }
 

--- a/ScintillaAppTests/ParserTests.swift
+++ b/ScintillaAppTests/ParserTests.swift
@@ -283,6 +283,53 @@ struct ParserTests {
         #expect(actual == expected)
     }
 
+    @Test func parseLetDeclarationWithDestructuring() throws {
+        let source = "let (a, b, c) = (1, 2, 3)"
+        var tokenizer = Tokenizer(source: source)
+        let tokens = try! tokenizer.scanTokens()
+        var parser = Parser(tokens: tokens)
+
+        let actual = try parser.parseStatement()!
+        let expected: Statement<UnresolvedLocation> =
+            .letDeclaration(
+                .tuple3(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 5, length: 1))),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 8, length: 1))),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 11, length: 1)))),
+                Token(
+                    type: .equal,
+                    lexeme: makeLexeme(source: source, offset: 14, length: 1)),
+                .tuple3(
+                    Token(
+                        type: .leftParen,
+                        lexeme: makeLexeme(source: source, offset: 16, length: 1)),
+                    .doubleLiteral(
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 17, length: 1)),
+                        1),
+                    .doubleLiteral(
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 20, length: 1)),
+                        2),
+                    .doubleLiteral(
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 23, length: 1)),
+                        3)))
+        #expect(actual == expected)
+    }
+
     @Test func parseFunctionDeclaration() throws {
         let source = """
 func hypotenuse(a, b) {
@@ -320,36 +367,143 @@ func hypotenuse(a, b) {
         let actual = try parser.parseStatement()!
         let expected: Statement<UnresolvedLocation> =
             .functionDeclaration(
-                Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 10)),
+                Token(
+                    type: .identifier,
+                    lexeme: makeLexeme(source: source, offset: 5, length: 10)),
                 [
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 16, length: 1)),
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 19, length: 1)),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 16, length: 1)),
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 16, length: 1)))),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 19, length: 1)),
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 19, length: 1)))),
                 ],
                 [],
                 .binary(
                     .binary(
                         .binary(
                             .variable(
-                                Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 29, length: 1)),
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 29, length: 1)),
                                 UnresolvedLocation()),
-                            Token(type: .caret, lexeme: makeLexeme(source: source, offset: 30, length: 1)),
+                            Token(
+                                type: .caret,
+                                lexeme: makeLexeme(source: source, offset: 30, length: 1)),
                             .doubleLiteral(
-                                Token(type: .double, lexeme: makeLexeme(source: source, offset: 31, length: 1)),
+                                Token(
+                                    type: .double,
+                                    lexeme: makeLexeme(source: source, offset: 31, length: 1)),
                                 2)),
-                        Token(type: .plus, lexeme: makeLexeme(source: source, offset: 33, length: 1)),
+                        Token(
+                            type: .plus,
+                            lexeme: makeLexeme(source: source, offset: 33, length: 1)),
                         .binary(
                             .variable(
-                                Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 35, length: 1)),
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 35, length: 1)),
                                 UnresolvedLocation()),
-                            Token(type: .caret, lexeme: makeLexeme(source: source, offset: 36, length: 1)),
+                            Token(
+                                type: .caret,
+                                lexeme: makeLexeme(source: source, offset: 36, length: 1)),
                             .doubleLiteral(
-                                Token(type: .double, lexeme: makeLexeme(source: source, offset: 37, length: 1)),
+                                Token(
+                                    type: .double,
+                                    lexeme: makeLexeme(source: source, offset: 37, length: 1)),
                                 2))),
-                    Token(type: .caret, lexeme: makeLexeme(source: source, offset: 39, length: 1)),
+                    Token(
+                        type: .caret,
+                        lexeme: makeLexeme(source: source, offset: 39, length: 1)),
                     .doubleLiteral(
-                        Token(type: .double, lexeme: makeLexeme(source: source, offset: 40, length: 3)),
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 40, length: 3)),
                         0.5)))
         #expect(actual == expected)
+    }
+
+    @Test func parseFunctionDeclarationWithDestructuring() throws {
+        let source = """
+func foo(a, (b, c) as d) {
+    a + b
+}
+"""
+
+        var tokenizer = Tokenizer(source: source)
+        let tokens = try! tokenizer.scanTokens()
+        var parser = Parser(tokens: tokens)
+        let actual = try parser.parseStatement()!
+        let expected: Statement<UnresolvedLocation> =
+            .functionDeclaration(
+                Token(
+                    type: .identifier,
+                    lexeme: makeLexeme(source: source, offset: 5, length: 3)),
+                [
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 9, length: 1)),
+                        pattern: .variable(
+                            Token(type: .identifier,
+                                  lexeme: makeLexeme(source: source, offset: 9, length: 1)))),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 22, length: 1)),
+                        pattern: .tuple2(
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 13, length: 1))),
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 16, length: 1))))),
+                ],
+                [],
+                .binary(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 31, length: 1)),
+                        UnresolvedLocation()),
+                    Token(
+                        type: .plus,
+                        lexeme: makeLexeme(source: source, offset: 33, length: 1)),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 35, length: 1)),
+                        UnresolvedLocation())))
+        #expect(actual == expected)
+    }
+
+    @Test func parseFunctionDeclarationWithMissingAs() throws {
+        let source = """
+func foo(a, (b, c)) {
+    a + b
+}
+"""
+
+        var tokenizer = Tokenizer(source: source)
+        let tokens = try! tokenizer.scanTokens()
+        var parser = Parser(tokens: tokens)
+
+        let locToken = Token(type: .rightParen, lexeme: ")")
+        #expect(throws: ParseError.missingAs(locToken)) {
+            try parser.parseStatement()
+        }
     }
 
     @Test func parseFunctionCall() throws {
@@ -458,10 +612,22 @@ func hypotenuse(a, b) {
         let actual = try parser.parseExpression()
         let expected: Expression<UnresolvedLocation> =
             .lambda(
-                Token(type: .leftBrace, lexeme: makeLexeme(source: source, offset: 0, length: 1)),
+                Token(
+                    type: .leftBrace,
+                    lexeme: makeLexeme(source: source, offset: 0, length: 1)),
                 [
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 2, length: 1)),
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 1)),
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 2, length: 1)))),
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 5, length: 1)))),
                 ],
                 [],
                 .binary(
@@ -483,7 +649,9 @@ func hypotenuse(a, b) {
                                         lexeme: makeLexeme(source: source, offset: 14, length: 1)),
                                     UnresolvedLocation()))
                         ]),
-                    Token(type: .star, lexeme: makeLexeme(source: source, offset: 15, length: 3)),
+                    Token(
+                        type: .star,
+                        lexeme: makeLexeme(source: source, offset: 15, length: 3)),
                     .call(
                         .variable(
                             Token(
@@ -502,6 +670,64 @@ func hypotenuse(a, b) {
                                         lexeme: makeLexeme(source: source, offset: 20, length: 1)),
                                     UnresolvedLocation()))
                         ])))
+        #expect(actual == expected)
+    }
+
+    @Test func parseLambdaExpressionWithDestructuring() throws {
+        let source = "{ a, (b, c) in a + b + c }"
+
+        var tokenizer = Tokenizer(source: source)
+        let tokens = try! tokenizer.scanTokens()
+        var parser = Parser(tokens: tokens)
+
+        let actual = try parser.parseExpression()
+        let expected: Expression<UnresolvedLocation> =
+            .lambda(
+                Token(
+                    type: .leftBrace,
+                    lexeme: makeLexeme(source: source, offset: 0, length: 1)),
+                [
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(type: .identifier,
+                                  lexeme: makeLexeme(source: source, offset: 2, length: 1)))),
+                    Parameter(
+                        name: nil,
+                        pattern: .tuple2(
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 6, length: 1))),
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 9, length: 1))))),
+                ],
+                [],
+                .binary(
+                    .binary(
+                        .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 15, length: 1)),
+                            UnresolvedLocation()),
+                        Token(
+                            type: .plus,
+                            lexeme: makeLexeme(source: source, offset: 17, length: 1)),
+                        .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 19, length: 1)),
+                            UnresolvedLocation())),
+                    Token(
+                        type: .plus,
+                        lexeme: makeLexeme(source: source, offset: 21, length: 1)),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 23, length: 1)),
+                        UnresolvedLocation())))
         #expect(actual == expected)
     }
 

--- a/ScintillaAppTests/ParserTests.swift
+++ b/ScintillaAppTests/ParserTests.swift
@@ -270,7 +270,13 @@ struct ParserTests {
         let actual = try parser.parseStatement()!
         let expected: Statement<UnresolvedLocation> =
             .letDeclaration(
-                Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 4, length: 9)),
+                .variable(
+                    Token(
+                        type: .identifier,
+                        lexeme: makeLexeme(source: source, offset: 4, length: 9))),
+                Token(
+                    type: .equal,
+                    lexeme: makeLexeme(source: source, offset: 14, length: 1)),
                 .doubleLiteral(
                     Token(type: .double, lexeme: makeLexeme(source: source, offset: 16, length: 2)),
                     42))
@@ -529,9 +535,13 @@ World(
         let expected = Program(
             statements: [
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 4, length: 6))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 4, length: 6)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 11, length: 1)),
                     .call(
                         .variable(
                             Token(
@@ -649,9 +659,13 @@ World(
                                         0))),
                         ])),
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 139, length: 6))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 139, length: 6)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 146, length: 1)),
                     .list(
                         Token(
                             type: .leftBracket,
@@ -693,9 +707,13 @@ World(
                                 ])
                         ])),
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 196, length: 6))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 196, length: 6)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 203, length: 1)),
                     .list(
                         Token(
                             type: .leftBracket,

--- a/ScintillaAppTests/ParserTests.swift
+++ b/ScintillaAppTests/ParserTests.swift
@@ -330,6 +330,53 @@ struct ParserTests {
         #expect(actual == expected)
     }
 
+    @Test func parseLetDeclarationWithWildcard() throws {
+        let source = "let (a, _, c) = (1, 2, 3)"
+        var tokenizer = Tokenizer(source: source)
+        let tokens = try! tokenizer.scanTokens()
+        var parser = Parser(tokens: tokens)
+
+        let actual = try parser.parseStatement()!
+        let expected: Statement<UnresolvedLocation> =
+            .letDeclaration(
+                .tuple3(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 5, length: 1))),
+                    .wildcard(
+                        Token(
+                            type: .underscore,
+                            lexeme: makeLexeme(source: source, offset: 8, length: 1))),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 11, length: 1)))),
+                Token(
+                    type: .equal,
+                    lexeme: makeLexeme(source: source, offset: 14, length: 1)),
+                .tuple3(
+                    Token(
+                        type: .leftParen,
+                        lexeme: makeLexeme(source: source, offset: 16, length: 1)),
+                    .doubleLiteral(
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 17, length: 1)),
+                        1),
+                    .doubleLiteral(
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 20, length: 1)),
+                        2),
+                    .doubleLiteral(
+                        Token(
+                            type: .double,
+                            lexeme: makeLexeme(source: source, offset: 23, length: 1)),
+                        3)))
+        #expect(actual == expected)
+    }
+
     @Test func parseFunctionDeclaration() throws {
         let source = """
 func hypotenuse(a, b) {

--- a/ScintillaAppTests/ParserTests.swift
+++ b/ScintillaAppTests/ParserTests.swift
@@ -463,6 +463,7 @@ func hypotenuse(a, b) {
                     Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 2, length: 1)),
                     Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 1)),
                 ],
+                [],
                 .binary(
                     .call(
                         .variable(

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -159,6 +159,59 @@ func foo(a, (b, c) as d) {
         #expect(actual == expected)
     }
 
+    @Test func resolveFunctionDeclarationWithWildcard() throws {
+        let source = """
+func foo(a, (b, _) as d) {
+    a + b
+}
+"""
+        let actual = try resolveStatement(source: source)
+        let expected: Statement<ResolvedLocation> =
+            .functionDeclaration(
+                Token(
+                    type: .identifier,
+                    lexeme: makeLexeme(source: source, offset: 5, length: 3)),
+                [
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 9, length: 1)),
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 9, length: 1)))),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 22, length: 1)),
+                        pattern: .tuple2(
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 13, length: 1))),
+                            .wildcard(
+                                Token(
+                                    type: .underscore,
+                                    lexeme: makeLexeme(source: source, offset: 16, length: 1))))),
+                ],
+                [],
+                .binary(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 31, length: 1)),
+                        ResolvedLocation(depth: 0, index: 0)),
+                    Token(
+                        type: .plus,
+                        lexeme: makeLexeme(source: source, offset: 33, length: 1)),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 35, length: 1)),
+                        ResolvedLocation(depth: 0, index: 2))))
+        #expect(actual == expected)
+    }
+
     @Test func resolveLambdaExpression() throws {
         let source = "{ x, y, z in x + y + z - 1 }"
         let actual = try resolveExpression(source: source)

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -101,6 +101,7 @@ func hypotenuse(a, b) {
                     Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 1)),
                     Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 8, length: 1)),
                 ],
+                [],
                 .binary(
                     .binary(
                         .binary(

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -34,9 +34,13 @@ struct ResolverTests {
         let actual = try resolveStatement(source: source)
         let expected: Statement<ResolvedLocation> =
             .letDeclaration(
+                .variable(
+                    Token(
+                        type: .identifier,
+                        lexeme: makeLexeme(source: source, offset: 4, length: 6))),
                 Token(
-                    type: .identifier,
-                    lexeme: makeLexeme(source: source, offset: 4, length: 6)),
+                    type: .equal,
+                    lexeme: makeLexeme(source: source, offset: 11, length: 1)),
                 .doubleLiteral(
                     Token(
                         type: .double,
@@ -163,9 +167,13 @@ World(
         let expected = Program(
             statements: [
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 4, length: 6))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 4, length: 6)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 11, length: 1)),
                     .call(
                         .function(
                             Token(
@@ -303,9 +311,13 @@ World(
                                         0))),
                         ])),
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 139, length: 6))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 139, length: 6)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 146, length: 1)),
                     .list(
                         Token(
                             type: .leftBracket,
@@ -352,9 +364,13 @@ World(
                                 ])
                         ])),
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 196, length: 9))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 196, length: 9)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 206, length: 1)),
                     .call(
                         .function(
                             Token(
@@ -419,9 +435,13 @@ World(
                                     ]))
                         ])),
                 .letDeclaration(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 257, length: 6))),
                     Token(
-                        type: .identifier,
-                        lexeme: makeLexeme(source: source, offset: 257, length: 6)),
+                        type: .equal,
+                        lexeme: makeLexeme(source: source, offset: 264, length: 1)),
                     .list(
                         Token(
                             type: .leftBracket,

--- a/ScintillaAppTests/ResolverTests.swift
+++ b/ScintillaAppTests/ResolverTests.swift
@@ -58,10 +58,26 @@ func hypotenuse(a, b) {
         let actual = try resolveStatement(source: source)
         let expected: Statement<ResolvedLocation> =
             .functionDeclaration(
-                Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 10)),
+                Token(
+                    type: .identifier,
+                    lexeme: makeLexeme(source: source, offset: 5, length: 10)),
                 [
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 16, length: 1)),
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 19, length: 1)),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 16, length: 1)),
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 16, length: 1)))),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 19, length: 1)),
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 19, length: 1)))),
                 ],
                 [],
                 .binary(
@@ -90,6 +106,59 @@ func hypotenuse(a, b) {
         #expect(actual == expected)
     }
 
+    @Test func resolveFunctionDeclarationWithDestructuring() throws {
+        let source = """
+func foo(a, (b, c) as d) {
+    a + b
+}
+"""
+        let actual = try resolveStatement(source: source)
+        let expected: Statement<ResolvedLocation> =
+            .functionDeclaration(
+                Token(
+                    type: .identifier,
+                    lexeme: makeLexeme(source: source, offset: 5, length: 3)),
+                [
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 9, length: 1)),
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 9, length: 1)))),
+                    Parameter(
+                        name: Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 22, length: 1)),
+                        pattern: .tuple2(
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 13, length: 1))),
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 16, length: 1))))),
+                ],
+                [],
+                .binary(
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 31, length: 1)),
+                        ResolvedLocation(depth: 0, index: 0)),
+                    Token(
+                        type: .plus,
+                        lexeme: makeLexeme(source: source, offset: 33, length: 1)),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 35, length: 1)),
+                        ResolvedLocation(depth: 0, index: 2))))
+        #expect(actual == expected)
+    }
+
     @Test func resolveLambdaExpression() throws {
         let source = "{ x, y, z in x + y + z - 1 }"
         let actual = try resolveExpression(source: source)
@@ -97,9 +166,24 @@ func hypotenuse(a, b) {
             .lambda(
                 Token(type: .leftBrace, lexeme: makeLexeme(source: source, offset: 0, length: 1)),
                 [
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 2, length: 1)),
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 1)),
-                    Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 8, length: 1)),
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 2, length: 1)))),
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 5, length: 1)))),
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 8, length: 1)))),
                 ],
                 [],
                 .binary(
@@ -134,6 +218,58 @@ func hypotenuse(a, b) {
                             type: .double,
                             lexeme: makeLexeme(source: source, offset: 25, length: 1)),
                         1)))
+        #expect(actual == expected)
+    }
+
+    @Test func resolveLambdaExpressionWithDestructuring() throws {
+        let source = "{ a, (b, c) in a + b + c }"
+        let actual = try resolveExpression(source: source)
+        let expected: Expression<ResolvedLocation> =
+            .lambda(
+                Token(type: .leftBrace, lexeme: makeLexeme(source: source, offset: 0, length: 1)),
+                [
+                    Parameter(
+                        name: nil,
+                        pattern: .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 2, length: 1)))),
+                    Parameter(
+                        name: nil,
+                        pattern: .tuple2(
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 6, length: 1))),
+                            .variable(
+                                Token(
+                                    type: .identifier,
+                                    lexeme: makeLexeme(source: source, offset: 9, length: 1)))))
+                ],
+                [],
+                .binary(
+                    .binary(
+                        .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 15, length: 1)),
+                            ResolvedLocation(depth: 0, index: 0)),
+                        Token(
+                            type: .plus,
+                            lexeme: makeLexeme(source: source, offset: 17, length: 1)),
+                        .variable(
+                            Token(
+                                type: .identifier,
+                                lexeme: makeLexeme(source: source, offset: 19, length: 1)),
+                            ResolvedLocation(depth: 0, index: 1))),
+                    Token(
+                        type: .plus,
+                        lexeme: makeLexeme(source: source, offset: 21, length: 1)),
+                    .variable(
+                        Token(
+                            type: .identifier,
+                            lexeme: makeLexeme(source: source, offset: 23, length: 1)),
+                        ResolvedLocation(depth: 0, index: 2))))
         #expect(actual == expected)
     }
 

--- a/ScintillaAppTests/TokenizerTests.swift
+++ b/ScintillaAppTests/TokenizerTests.swift
@@ -52,7 +52,7 @@ struct TokenizerTests {
     }
 
     @Test func scanningOfKeywords() throws {
-        let source = "let in func true false"
+        let source = "let in func true false as"
         var tokenizer = Tokenizer(source: source)
 
         let actual = try! tokenizer.scanTokens()
@@ -62,7 +62,8 @@ struct TokenizerTests {
             Token(type: .func, lexeme: makeLexeme(source: source, offset: 7, length: 4)),
             Token(type: .true, lexeme: makeLexeme(source: source, offset: 12, length: 4)),
             Token(type: .false, lexeme: makeLexeme(source: source, offset: 17, length: 5)),
-            Token(type: .eof, lexeme: makeLexeme(source: source, offset: 18, length: 0)),
+            Token(type: .as, lexeme: makeLexeme(source: source, offset: 23, length: 2)),
+            Token(type: .eof, lexeme: makeLexeme(source: source, offset: 24, length: 0)),
         ]
 
         #expect(actual == expected)

--- a/ScintillaAppTests/TokenizerTests.swift
+++ b/ScintillaAppTests/TokenizerTests.swift
@@ -161,4 +161,32 @@ let shape = Sphere()
 
         #expect(actual == expected)
     }
+
+    @Test func scanningOfLetDeclarationWithWildcard() throws {
+        let source = "let (r, _, b) = (1.0, 0.5, 0.0)"
+        var tokenizer = Tokenizer(source: source)
+
+        let actual = try! tokenizer.scanTokens()
+        let expected: [Token] = [
+            Token(type: .let, lexeme: makeLexeme(source: source, offset: 0, length: 3)),
+            Token(type: .leftParen, lexeme: makeLexeme(source: source, offset: 4, length: 1)),
+            Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 5, length: 1)),
+            Token(type: .comma, lexeme: makeLexeme(source: source, offset: 6, length: 1)),
+            Token(type: .underscore, lexeme: makeLexeme(source: source, offset: 8, length: 1)),
+            Token(type: .comma, lexeme: makeLexeme(source: source, offset: 9, length: 1)),
+            Token(type: .identifier, lexeme: makeLexeme(source: source, offset: 11, length: 1)),
+            Token(type: .rightParen, lexeme: makeLexeme(source: source, offset: 12, length: 1)),
+            Token(type: .equal, lexeme: makeLexeme(source: source, offset: 14, length: 1)),
+            Token(type: .leftParen, lexeme: makeLexeme(source: source, offset: 16, length: 1)),
+            Token(type: .double, lexeme: makeLexeme(source: source, offset: 17, length: 3)),
+            Token(type: .comma, lexeme: makeLexeme(source: source, offset: 20, length: 1)),
+            Token(type: .double, lexeme: makeLexeme(source: source, offset: 22, length: 3)),
+            Token(type: .comma, lexeme: makeLexeme(source: source, offset: 25, length: 1)),
+            Token(type: .double, lexeme: makeLexeme(source: source, offset: 27, length: 3)),
+            Token(type: .rightParen, lexeme: makeLexeme(source: source, offset: 30, length: 1)),
+            Token(type: .eof, lexeme: makeLexeme(source: source, offset: 31, length: 0)),
+        ]
+
+        #expect(actual == expected)
+    }
 }


### PR DESCRIPTION
This PR allows for destructuring of tuple expressions in the following contexts:

* `let` statements
* function declarations
* lambda expressions

Additionally:

* lambda expressions can now have `let` statements in them, with a terminal expression as their return values
* wildcards, using the `_` character, can be used to ignore components of a tuple, as in
```
let (a, _, c) = (1, 2, 3)
```
* destructuring patterns can be nested, as in the following:
```
let (a, (b, (c, d))) = (1, (2, (3, 4)))
```

Changes were clearly necessary in the tokenizer, parser, resolver, and evaluator, but they also needed to be made in `UserDefinedFunction` in order for lambdas and functions to work properly. I also needed to introduce the concept of an `AssignmentPattern` since `Token` was no longer sufficient to express function parameters and the left hand sides of `let` expressions. I also needed to introduce `Parameter` to allow for a name to be optionally be associated with a pattern. That is, functions _require_ names for all top-level parameters using the `as` clause; this is so that the current mechanism for looking up functions by their names and parameter names can still be be used. (I may need to revisit this later.) Lambdas do _not_ require top level names for their parameters.

I strove to centralize most of the processing of argument patterns for `let` statements, function declarations, and lambdas in the parser, resolver, and evaluator, and was even able to use `handlePattern()` in `UserDefinedFunction.call()`. 

Unit tests and the README have all been updated.